### PR TITLE
Kotlin native further changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ commands:
       target:
         description: Target platform for which to run conformance tests
         type: string
+
     steps:
       - attach_workspace:
           at: ~/project
@@ -50,6 +51,10 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: Install Kotlin/Native compiler dependencies
+          command: sudo apt update && sudo apt install libncurses5
 
       - run:
           name: Collect files for dependencies cache key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
           name: Save dependencies cache
           paths:
             - ~/.gradle
+            - ~/.konan
           key: v2-dependencies-{{ checksum "/tmp/circleci_cache_key" }}
           when: always
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,28 @@ executors:
     docker:
       - image: cimg/base:2020.01
 
+commands:
+
+  conformance_test:
+    parameters:
+      target:
+        description: Target platform for which to run conformance tests
+        type: string
+    steps:
+      - attach_workspace:
+          at: ~/project
+
+      - restore_cache:
+          name: Restore protobuf cache
+          keys:
+            - v3-protobuf-3.10.1
+
+      - run:
+          name: Run << parameters.target >> conformance tests
+          command: |
+            export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
+            ./conformance/test-conformance.sh << parameters.target >>
+
 jobs:
 
   build:
@@ -122,7 +144,7 @@ jobs:
             - conformance/js/failing_tests.txt
             - conformance/js/run.sh
             # native
-            - conformance/native/build/bin/linux/debugExecutable/conformance.kexe
+            - conformance/native/build/bin/linux/conformanceReleaseExecutable/conformance.kexe
             - conformance/native/failing_tests.txt
 
       - save_cache:
@@ -139,58 +161,24 @@ jobs:
       name: jvm
 
     steps:
-      - attach_workspace:
-          at: ~/project
-
-      - restore_cache:
-          name: Restore protobuf cache
-          keys:
-            - v3-protobuf-3.10.1
-
-      - run:
-          name: Run JVM conformance tests
-          command: |
-            export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
-            ./conformance/test-conformance.sh jvm
-
+      - conformance_test:
+          target: jvm
 
   conformance_js:
     executor:
       name: nodejs
 
     steps:
-      - attach_workspace:
-          at: ~/project
-
-      - restore_cache:
-          name: Restore protobuf cache
-          keys:
-            - v3-protobuf-3.10.1
-
-      - run:
-          name: Run JS conformance tests
-          command: |
-            export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
-            ./conformance/test-conformance.sh js
+      - conformance_test:
+          target: js
 
   conformance_native:
     executor:
       name: native
 
     steps:
-      - attach_workspace:
-          at: ~/project
-
-      - restore_cache:
-          name: Restore protobuf cache
-          keys:
-            - v3-protobuf-3.10.1
-
-      - run:
-          name: Run Native conformance tests
-          command: |
-            export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
-            ./conformance/test-conformance.sh linux
+      - conformance_test:
+          target: linux
 
   build_examples:
     executor:

--- a/README.md
+++ b/README.md
@@ -184,13 +184,6 @@ rename it to `protoc-gen-kotlin`, make the file executable (`chmod +x protoc-gen
 protoc --kotlin_out=src/main/kotlin sample.proto
 ```
 
-For Windows however, `protoc` doesn't support finding `protoc-gen-kotlin.bat` on the `PATH`. So it has to be specified
-explicitly as a plugin:
-
-```
-protoc --kotlin_out=src/main/kotlin --plugin=protoc-gen-kotlin=path/to/protoc-gen-kotlin.bat sample.proto
-```
-
 The file is generated as `sample.kt` in the subdirectories specified by the package. Like other `X_out` arguments,
 comma-separated options can be added to `--kotlin_out` before the colon and out dir path. To explicitly set the Kotlin
 package to `my.pkg`, use the `kotlin_package` option like so:

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
         }
 
         val nativeMain by creating {
+            dependsOn(commonMain)
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -22,6 +24,18 @@ kotlin {
     linuxX64("linux")
     // Uncomment to enable Windows
     // mingwX64("windows")
+
+    targets.withType<KotlinNativeTarget> {
+        val main by compilations.getting {
+            defaultSourceSet {
+                kotlin.srcDir("src/nativeMain/kotlin")
+            }
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")
+            }
+        }
+    }
 
     sourceSets {
         val commonMain by getting {
@@ -69,27 +83,6 @@ kotlin {
                 implementation(kotlin("test-js"))
             }
         }
-
-        val nativeMain by creating {
-            dependsOn(commonMain)
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")
-            }
-        }
-
-        val linuxMain by getting {
-            dependsOn(nativeMain)
-        }
-
-        val macosMain by getting {
-            dependsOn(nativeMain)
-        }
-
-        // Uncomment to enable Windows
-        //val windowsMain by getting {
-        //    dependsOn(nativeMain)
-        //}
     }
 }
 

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
@@ -228,7 +228,7 @@ private fun FailureSet.protoMergeImpl(plus: FailureSet?): FailureSet = plus?.cop
 
 private fun FailureSet.protoSizeImpl(): Int {
     var protoSize = 0
-    if (failure.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * failure.size) + failure.sumBy(pbandk.SizerImpl::stringSize)
+    if (failure.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * failure.size) + failure.sumBy(pbandk.Sizer::stringSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -275,16 +275,16 @@ private fun ConformanceRequest.protoMergeImpl(plus: ConformanceRequest?): Confor
 
 private fun ConformanceRequest.protoSizeImpl(): Int {
     var protoSize = 0
-    if (requestedOutputFormat.value != 0) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.enumSize(requestedOutputFormat)
-    if (messageType.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(messageType)
-    if (testCategory.value != 0) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.enumSize(testCategory)
-    if (jspbEncodingOptions != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.messageSize(jspbEncodingOptions)
-    if (printUnknownFields) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.boolSize(printUnknownFields)
+    if (requestedOutputFormat.value != 0) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.enumSize(requestedOutputFormat)
+    if (messageType.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(messageType)
+    if (testCategory.value != 0) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.enumSize(testCategory)
+    if (jspbEncodingOptions != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.messageSize(jspbEncodingOptions)
+    if (printUnknownFields) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.boolSize(printUnknownFields)
     when (payload) {
-        is ConformanceRequest.Payload.ProtobufPayload -> protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.bytesSize(payload.value)
-        is ConformanceRequest.Payload.JsonPayload -> protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(payload.value)
-        is ConformanceRequest.Payload.JspbPayload -> protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.stringSize(payload.value)
-        is ConformanceRequest.Payload.TextPayload -> protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.stringSize(payload.value)
+        is ConformanceRequest.Payload.ProtobufPayload -> protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.bytesSize(payload.value)
+        is ConformanceRequest.Payload.JsonPayload -> protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(payload.value)
+        is ConformanceRequest.Payload.JspbPayload -> protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.stringSize(payload.value)
+        is ConformanceRequest.Payload.TextPayload -> protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.stringSize(payload.value)
     }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
@@ -371,14 +371,14 @@ private fun ConformanceResponse.protoMergeImpl(plus: ConformanceResponse?): Conf
 private fun ConformanceResponse.protoSizeImpl(): Int {
     var protoSize = 0
     when (result) {
-        is ConformanceResponse.Result.ParseError -> protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.SerializeError -> protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.RuntimeError -> protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.ProtobufPayload -> protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.bytesSize(result.value)
-        is ConformanceResponse.Result.JsonPayload -> protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.Skipped -> protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.JspbPayload -> protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.stringSize(result.value)
-        is ConformanceResponse.Result.TextPayload -> protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.stringSize(result.value)
+        is ConformanceResponse.Result.ParseError -> protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.SerializeError -> protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.RuntimeError -> protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.ProtobufPayload -> protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.bytesSize(result.value)
+        is ConformanceResponse.Result.JsonPayload -> protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.Skipped -> protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.JspbPayload -> protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.stringSize(result.value)
+        is ConformanceResponse.Result.TextPayload -> protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.stringSize(result.value)
     }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
@@ -453,7 +453,7 @@ private fun JspbEncodingConfig.protoMergeImpl(plus: JspbEncodingConfig?): JspbEn
 
 private fun JspbEncodingConfig.protoSizeImpl(): Int {
     var protoSize = 0
-    if (useJspbArrayAnyFormat) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(useJspbArrayAnyFormat)
+    if (useJspbArrayAnyFormat) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(useJspbArrayAnyFormat)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
@@ -1276,124 +1276,124 @@ private fun TestAllTypesProto2.protoMergeImpl(plus: TestAllTypesProto2?): TestAl
 
 private fun TestAllTypesProto2.protoSizeImpl(): Int {
     var protoSize = 0
-    if (optionalInt32 != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(optionalInt32)
-    if (optionalInt64 != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int64Size(optionalInt64)
-    if (optionalUint32 != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.uInt32Size(optionalUint32)
-    if (optionalUint64 != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.uInt64Size(optionalUint64)
-    if (optionalSint32 != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.sInt32Size(optionalSint32)
-    if (optionalSint64 != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.sInt64Size(optionalSint64)
-    if (optionalFixed32 != null) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.fixed32Size(optionalFixed32)
-    if (optionalFixed64 != null) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.fixed64Size(optionalFixed64)
-    if (optionalSfixed32 != null) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.sFixed32Size(optionalSfixed32)
-    if (optionalSfixed64 != null) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.sFixed64Size(optionalSfixed64)
-    if (optionalFloat != null) protoSize += pbandk.SizerImpl.tagSize(11) + pbandk.SizerImpl.floatSize(optionalFloat)
-    if (optionalDouble != null) protoSize += pbandk.SizerImpl.tagSize(12) + pbandk.SizerImpl.doubleSize(optionalDouble)
-    if (optionalBool != null) protoSize += pbandk.SizerImpl.tagSize(13) + pbandk.SizerImpl.boolSize(optionalBool)
-    if (optionalString != null) protoSize += pbandk.SizerImpl.tagSize(14) + pbandk.SizerImpl.stringSize(optionalString)
-    if (optionalBytes != null) protoSize += pbandk.SizerImpl.tagSize(15) + pbandk.SizerImpl.bytesSize(optionalBytes)
-    if (optionalNestedMessage != null) protoSize += pbandk.SizerImpl.tagSize(18) + pbandk.SizerImpl.messageSize(optionalNestedMessage)
-    if (optionalForeignMessage != null) protoSize += pbandk.SizerImpl.tagSize(19) + pbandk.SizerImpl.messageSize(optionalForeignMessage)
-    if (optionalNestedEnum != null) protoSize += pbandk.SizerImpl.tagSize(21) + pbandk.SizerImpl.enumSize(optionalNestedEnum)
-    if (optionalForeignEnum != null) protoSize += pbandk.SizerImpl.tagSize(22) + pbandk.SizerImpl.enumSize(optionalForeignEnum)
-    if (optionalStringPiece != null) protoSize += pbandk.SizerImpl.tagSize(24) + pbandk.SizerImpl.stringSize(optionalStringPiece)
-    if (optionalCord != null) protoSize += pbandk.SizerImpl.tagSize(25) + pbandk.SizerImpl.stringSize(optionalCord)
-    if (recursiveMessage != null) protoSize += pbandk.SizerImpl.tagSize(27) + pbandk.SizerImpl.messageSize(recursiveMessage)
-    if (repeatedInt32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(31) * repeatedInt32.size) + repeatedInt32.sumBy(pbandk.SizerImpl::int32Size)
-    if (repeatedInt64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(32) * repeatedInt64.size) + repeatedInt64.sumBy(pbandk.SizerImpl::int64Size)
-    if (repeatedUint32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(33) * repeatedUint32.size) + repeatedUint32.sumBy(pbandk.SizerImpl::uInt32Size)
-    if (repeatedUint64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(34) * repeatedUint64.size) + repeatedUint64.sumBy(pbandk.SizerImpl::uInt64Size)
-    if (repeatedSint32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(35) * repeatedSint32.size) + repeatedSint32.sumBy(pbandk.SizerImpl::sInt32Size)
-    if (repeatedSint64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(36) * repeatedSint64.size) + repeatedSint64.sumBy(pbandk.SizerImpl::sInt64Size)
-    if (repeatedFixed32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(37) * repeatedFixed32.size) + repeatedFixed32.sumBy(pbandk.SizerImpl::fixed32Size)
-    if (repeatedFixed64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(38) * repeatedFixed64.size) + repeatedFixed64.sumBy(pbandk.SizerImpl::fixed64Size)
-    if (repeatedSfixed32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(39) * repeatedSfixed32.size) + repeatedSfixed32.sumBy(pbandk.SizerImpl::sFixed32Size)
-    if (repeatedSfixed64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(40) * repeatedSfixed64.size) + repeatedSfixed64.sumBy(pbandk.SizerImpl::sFixed64Size)
-    if (repeatedFloat.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(41) * repeatedFloat.size) + repeatedFloat.sumBy(pbandk.SizerImpl::floatSize)
-    if (repeatedDouble.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(42) * repeatedDouble.size) + repeatedDouble.sumBy(pbandk.SizerImpl::doubleSize)
-    if (repeatedBool.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(43) * repeatedBool.size) + repeatedBool.sumBy(pbandk.SizerImpl::boolSize)
-    if (repeatedString.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(44) * repeatedString.size) + repeatedString.sumBy(pbandk.SizerImpl::stringSize)
-    if (repeatedBytes.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(45) * repeatedBytes.size) + repeatedBytes.sumBy(pbandk.SizerImpl::bytesSize)
-    if (repeatedNestedMessage.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(48) * repeatedNestedMessage.size) + repeatedNestedMessage.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedForeignMessage.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(49) * repeatedForeignMessage.size) + repeatedForeignMessage.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(51) * repeatedNestedEnum.size) + repeatedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (repeatedForeignEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(52) * repeatedForeignEnum.size) + repeatedForeignEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (repeatedStringPiece.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(54) * repeatedStringPiece.size) + repeatedStringPiece.sumBy(pbandk.SizerImpl::stringSize)
-    if (repeatedCord.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(55) * repeatedCord.size) + repeatedCord.sumBy(pbandk.SizerImpl::stringSize)
-    if (packedInt32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(75) + pbandk.SizerImpl.packedRepeatedSize(packedInt32, pbandk.SizerImpl::int32Size)
-    if (packedInt64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(76) + pbandk.SizerImpl.packedRepeatedSize(packedInt64, pbandk.SizerImpl::int64Size)
-    if (packedUint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(77) + pbandk.SizerImpl.packedRepeatedSize(packedUint32, pbandk.SizerImpl::uInt32Size)
-    if (packedUint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(78) + pbandk.SizerImpl.packedRepeatedSize(packedUint64, pbandk.SizerImpl::uInt64Size)
-    if (packedSint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(79) + pbandk.SizerImpl.packedRepeatedSize(packedSint32, pbandk.SizerImpl::sInt32Size)
-    if (packedSint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(80) + pbandk.SizerImpl.packedRepeatedSize(packedSint64, pbandk.SizerImpl::sInt64Size)
-    if (packedFixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(81) + pbandk.SizerImpl.packedRepeatedSize(packedFixed32, pbandk.SizerImpl::fixed32Size)
-    if (packedFixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(82) + pbandk.SizerImpl.packedRepeatedSize(packedFixed64, pbandk.SizerImpl::fixed64Size)
-    if (packedSfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(83) + pbandk.SizerImpl.packedRepeatedSize(packedSfixed32, pbandk.SizerImpl::sFixed32Size)
-    if (packedSfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(84) + pbandk.SizerImpl.packedRepeatedSize(packedSfixed64, pbandk.SizerImpl::sFixed64Size)
-    if (packedFloat.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(85) + pbandk.SizerImpl.packedRepeatedSize(packedFloat, pbandk.SizerImpl::floatSize)
-    if (packedDouble.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(86) + pbandk.SizerImpl.packedRepeatedSize(packedDouble, pbandk.SizerImpl::doubleSize)
-    if (packedBool.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(87) + pbandk.SizerImpl.packedRepeatedSize(packedBool, pbandk.SizerImpl::boolSize)
-    if (packedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(88) * packedNestedEnum.size) + packedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (unpackedInt32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(89) * unpackedInt32.size) + unpackedInt32.sumBy(pbandk.SizerImpl::int32Size)
-    if (unpackedInt64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(90) * unpackedInt64.size) + unpackedInt64.sumBy(pbandk.SizerImpl::int64Size)
-    if (unpackedUint32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(91) * unpackedUint32.size) + unpackedUint32.sumBy(pbandk.SizerImpl::uInt32Size)
-    if (unpackedUint64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(92) * unpackedUint64.size) + unpackedUint64.sumBy(pbandk.SizerImpl::uInt64Size)
-    if (unpackedSint32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(93) * unpackedSint32.size) + unpackedSint32.sumBy(pbandk.SizerImpl::sInt32Size)
-    if (unpackedSint64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(94) * unpackedSint64.size) + unpackedSint64.sumBy(pbandk.SizerImpl::sInt64Size)
-    if (unpackedFixed32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(95) * unpackedFixed32.size) + unpackedFixed32.sumBy(pbandk.SizerImpl::fixed32Size)
-    if (unpackedFixed64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(96) * unpackedFixed64.size) + unpackedFixed64.sumBy(pbandk.SizerImpl::fixed64Size)
-    if (unpackedSfixed32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(97) * unpackedSfixed32.size) + unpackedSfixed32.sumBy(pbandk.SizerImpl::sFixed32Size)
-    if (unpackedSfixed64.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(98) * unpackedSfixed64.size) + unpackedSfixed64.sumBy(pbandk.SizerImpl::sFixed64Size)
-    if (unpackedFloat.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(99) * unpackedFloat.size) + unpackedFloat.sumBy(pbandk.SizerImpl::floatSize)
-    if (unpackedDouble.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(100) * unpackedDouble.size) + unpackedDouble.sumBy(pbandk.SizerImpl::doubleSize)
-    if (unpackedBool.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(101) * unpackedBool.size) + unpackedBool.sumBy(pbandk.SizerImpl::boolSize)
-    if (unpackedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(102) * unpackedNestedEnum.size) + unpackedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (mapInt32Int32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(56, mapInt32Int32, pbandk.conformance.pb.TestAllTypesProto2::MapInt32Int32Entry)
-    if (mapInt64Int64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(57, mapInt64Int64, pbandk.conformance.pb.TestAllTypesProto2::MapInt64Int64Entry)
-    if (mapUint32Uint32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(58, mapUint32Uint32, pbandk.conformance.pb.TestAllTypesProto2::MapUint32Uint32Entry)
-    if (mapUint64Uint64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(59, mapUint64Uint64, pbandk.conformance.pb.TestAllTypesProto2::MapUint64Uint64Entry)
-    if (mapSint32Sint32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(60, mapSint32Sint32, pbandk.conformance.pb.TestAllTypesProto2::MapSint32Sint32Entry)
-    if (mapSint64Sint64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(61, mapSint64Sint64, pbandk.conformance.pb.TestAllTypesProto2::MapSint64Sint64Entry)
-    if (mapFixed32Fixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(62, mapFixed32Fixed32, pbandk.conformance.pb.TestAllTypesProto2::MapFixed32Fixed32Entry)
-    if (mapFixed64Fixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(63, mapFixed64Fixed64, pbandk.conformance.pb.TestAllTypesProto2::MapFixed64Fixed64Entry)
-    if (mapSfixed32Sfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(64, mapSfixed32Sfixed32, pbandk.conformance.pb.TestAllTypesProto2::MapSfixed32Sfixed32Entry)
-    if (mapSfixed64Sfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(65, mapSfixed64Sfixed64, pbandk.conformance.pb.TestAllTypesProto2::MapSfixed64Sfixed64Entry)
-    if (mapInt32Float.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(66, mapInt32Float, pbandk.conformance.pb.TestAllTypesProto2::MapInt32FloatEntry)
-    if (mapInt32Double.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(67, mapInt32Double, pbandk.conformance.pb.TestAllTypesProto2::MapInt32DoubleEntry)
-    if (mapBoolBool.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(68, mapBoolBool, pbandk.conformance.pb.TestAllTypesProto2::MapBoolBoolEntry)
-    if (mapStringString.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(69, mapStringString, pbandk.conformance.pb.TestAllTypesProto2::MapStringStringEntry)
-    if (mapStringBytes.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(70, mapStringBytes, pbandk.conformance.pb.TestAllTypesProto2::MapStringBytesEntry)
-    if (mapStringNestedMessage.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(71, mapStringNestedMessage, pbandk.conformance.pb.TestAllTypesProto2::MapStringNestedMessageEntry)
-    if (mapStringForeignMessage.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(72, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignMessageEntry)
-    if (mapStringNestedEnum.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(73, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringNestedEnumEntry)
-    if (mapStringForeignEnum.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(74, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignEnumEntry)
-    if (fieldname1 != null) protoSize += pbandk.SizerImpl.tagSize(401) + pbandk.SizerImpl.int32Size(fieldname1)
-    if (fieldName2 != null) protoSize += pbandk.SizerImpl.tagSize(402) + pbandk.SizerImpl.int32Size(fieldName2)
-    if (fieldName3 != null) protoSize += pbandk.SizerImpl.tagSize(403) + pbandk.SizerImpl.int32Size(fieldName3)
-    if (field_name4 != null) protoSize += pbandk.SizerImpl.tagSize(404) + pbandk.SizerImpl.int32Size(field_name4)
-    if (field0name5 != null) protoSize += pbandk.SizerImpl.tagSize(405) + pbandk.SizerImpl.int32Size(field0name5)
-    if (field0Name6 != null) protoSize += pbandk.SizerImpl.tagSize(406) + pbandk.SizerImpl.int32Size(field0Name6)
-    if (fieldName7 != null) protoSize += pbandk.SizerImpl.tagSize(407) + pbandk.SizerImpl.int32Size(fieldName7)
-    if (fieldName8 != null) protoSize += pbandk.SizerImpl.tagSize(408) + pbandk.SizerImpl.int32Size(fieldName8)
-    if (fieldName9 != null) protoSize += pbandk.SizerImpl.tagSize(409) + pbandk.SizerImpl.int32Size(fieldName9)
-    if (fieldName10 != null) protoSize += pbandk.SizerImpl.tagSize(410) + pbandk.SizerImpl.int32Size(fieldName10)
-    if (fIELDNAME11 != null) protoSize += pbandk.SizerImpl.tagSize(411) + pbandk.SizerImpl.int32Size(fIELDNAME11)
-    if (fIELDName12 != null) protoSize += pbandk.SizerImpl.tagSize(412) + pbandk.SizerImpl.int32Size(fIELDName12)
-    if (_fieldName13 != null) protoSize += pbandk.SizerImpl.tagSize(413) + pbandk.SizerImpl.int32Size(_fieldName13)
-    if (_FieldName14 != null) protoSize += pbandk.SizerImpl.tagSize(414) + pbandk.SizerImpl.int32Size(_FieldName14)
-    if (field_name15 != null) protoSize += pbandk.SizerImpl.tagSize(415) + pbandk.SizerImpl.int32Size(field_name15)
-    if (field_Name16 != null) protoSize += pbandk.SizerImpl.tagSize(416) + pbandk.SizerImpl.int32Size(field_Name16)
-    if (fieldName17_ != null) protoSize += pbandk.SizerImpl.tagSize(417) + pbandk.SizerImpl.int32Size(fieldName17_)
-    if (fieldName18_ != null) protoSize += pbandk.SizerImpl.tagSize(418) + pbandk.SizerImpl.int32Size(fieldName18_)
+    if (optionalInt32 != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(optionalInt32)
+    if (optionalInt64 != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int64Size(optionalInt64)
+    if (optionalUint32 != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.uInt32Size(optionalUint32)
+    if (optionalUint64 != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.uInt64Size(optionalUint64)
+    if (optionalSint32 != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.sInt32Size(optionalSint32)
+    if (optionalSint64 != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.sInt64Size(optionalSint64)
+    if (optionalFixed32 != null) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.fixed32Size(optionalFixed32)
+    if (optionalFixed64 != null) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.fixed64Size(optionalFixed64)
+    if (optionalSfixed32 != null) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.sFixed32Size(optionalSfixed32)
+    if (optionalSfixed64 != null) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.sFixed64Size(optionalSfixed64)
+    if (optionalFloat != null) protoSize += pbandk.Sizer.tagSize(11) + pbandk.Sizer.floatSize(optionalFloat)
+    if (optionalDouble != null) protoSize += pbandk.Sizer.tagSize(12) + pbandk.Sizer.doubleSize(optionalDouble)
+    if (optionalBool != null) protoSize += pbandk.Sizer.tagSize(13) + pbandk.Sizer.boolSize(optionalBool)
+    if (optionalString != null) protoSize += pbandk.Sizer.tagSize(14) + pbandk.Sizer.stringSize(optionalString)
+    if (optionalBytes != null) protoSize += pbandk.Sizer.tagSize(15) + pbandk.Sizer.bytesSize(optionalBytes)
+    if (optionalNestedMessage != null) protoSize += pbandk.Sizer.tagSize(18) + pbandk.Sizer.messageSize(optionalNestedMessage)
+    if (optionalForeignMessage != null) protoSize += pbandk.Sizer.tagSize(19) + pbandk.Sizer.messageSize(optionalForeignMessage)
+    if (optionalNestedEnum != null) protoSize += pbandk.Sizer.tagSize(21) + pbandk.Sizer.enumSize(optionalNestedEnum)
+    if (optionalForeignEnum != null) protoSize += pbandk.Sizer.tagSize(22) + pbandk.Sizer.enumSize(optionalForeignEnum)
+    if (optionalStringPiece != null) protoSize += pbandk.Sizer.tagSize(24) + pbandk.Sizer.stringSize(optionalStringPiece)
+    if (optionalCord != null) protoSize += pbandk.Sizer.tagSize(25) + pbandk.Sizer.stringSize(optionalCord)
+    if (recursiveMessage != null) protoSize += pbandk.Sizer.tagSize(27) + pbandk.Sizer.messageSize(recursiveMessage)
+    if (repeatedInt32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(31) * repeatedInt32.size) + repeatedInt32.sumBy(pbandk.Sizer::int32Size)
+    if (repeatedInt64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(32) * repeatedInt64.size) + repeatedInt64.sumBy(pbandk.Sizer::int64Size)
+    if (repeatedUint32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(33) * repeatedUint32.size) + repeatedUint32.sumBy(pbandk.Sizer::uInt32Size)
+    if (repeatedUint64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(34) * repeatedUint64.size) + repeatedUint64.sumBy(pbandk.Sizer::uInt64Size)
+    if (repeatedSint32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(35) * repeatedSint32.size) + repeatedSint32.sumBy(pbandk.Sizer::sInt32Size)
+    if (repeatedSint64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(36) * repeatedSint64.size) + repeatedSint64.sumBy(pbandk.Sizer::sInt64Size)
+    if (repeatedFixed32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(37) * repeatedFixed32.size) + repeatedFixed32.sumBy(pbandk.Sizer::fixed32Size)
+    if (repeatedFixed64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(38) * repeatedFixed64.size) + repeatedFixed64.sumBy(pbandk.Sizer::fixed64Size)
+    if (repeatedSfixed32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(39) * repeatedSfixed32.size) + repeatedSfixed32.sumBy(pbandk.Sizer::sFixed32Size)
+    if (repeatedSfixed64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(40) * repeatedSfixed64.size) + repeatedSfixed64.sumBy(pbandk.Sizer::sFixed64Size)
+    if (repeatedFloat.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(41) * repeatedFloat.size) + repeatedFloat.sumBy(pbandk.Sizer::floatSize)
+    if (repeatedDouble.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(42) * repeatedDouble.size) + repeatedDouble.sumBy(pbandk.Sizer::doubleSize)
+    if (repeatedBool.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(43) * repeatedBool.size) + repeatedBool.sumBy(pbandk.Sizer::boolSize)
+    if (repeatedString.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(44) * repeatedString.size) + repeatedString.sumBy(pbandk.Sizer::stringSize)
+    if (repeatedBytes.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(45) * repeatedBytes.size) + repeatedBytes.sumBy(pbandk.Sizer::bytesSize)
+    if (repeatedNestedMessage.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(48) * repeatedNestedMessage.size) + repeatedNestedMessage.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedForeignMessage.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(49) * repeatedForeignMessage.size) + repeatedForeignMessage.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(51) * repeatedNestedEnum.size) + repeatedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (repeatedForeignEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(52) * repeatedForeignEnum.size) + repeatedForeignEnum.sumBy(pbandk.Sizer::enumSize)
+    if (repeatedStringPiece.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(54) * repeatedStringPiece.size) + repeatedStringPiece.sumBy(pbandk.Sizer::stringSize)
+    if (repeatedCord.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(55) * repeatedCord.size) + repeatedCord.sumBy(pbandk.Sizer::stringSize)
+    if (packedInt32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(75) + pbandk.Sizer.packedRepeatedSize(packedInt32, pbandk.Sizer::int32Size)
+    if (packedInt64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(76) + pbandk.Sizer.packedRepeatedSize(packedInt64, pbandk.Sizer::int64Size)
+    if (packedUint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(77) + pbandk.Sizer.packedRepeatedSize(packedUint32, pbandk.Sizer::uInt32Size)
+    if (packedUint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(78) + pbandk.Sizer.packedRepeatedSize(packedUint64, pbandk.Sizer::uInt64Size)
+    if (packedSint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(79) + pbandk.Sizer.packedRepeatedSize(packedSint32, pbandk.Sizer::sInt32Size)
+    if (packedSint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(80) + pbandk.Sizer.packedRepeatedSize(packedSint64, pbandk.Sizer::sInt64Size)
+    if (packedFixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(81) + pbandk.Sizer.packedRepeatedSize(packedFixed32, pbandk.Sizer::fixed32Size)
+    if (packedFixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(82) + pbandk.Sizer.packedRepeatedSize(packedFixed64, pbandk.Sizer::fixed64Size)
+    if (packedSfixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(83) + pbandk.Sizer.packedRepeatedSize(packedSfixed32, pbandk.Sizer::sFixed32Size)
+    if (packedSfixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(84) + pbandk.Sizer.packedRepeatedSize(packedSfixed64, pbandk.Sizer::sFixed64Size)
+    if (packedFloat.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(85) + pbandk.Sizer.packedRepeatedSize(packedFloat, pbandk.Sizer::floatSize)
+    if (packedDouble.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(86) + pbandk.Sizer.packedRepeatedSize(packedDouble, pbandk.Sizer::doubleSize)
+    if (packedBool.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(87) + pbandk.Sizer.packedRepeatedSize(packedBool, pbandk.Sizer::boolSize)
+    if (packedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(88) * packedNestedEnum.size) + packedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (unpackedInt32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(89) * unpackedInt32.size) + unpackedInt32.sumBy(pbandk.Sizer::int32Size)
+    if (unpackedInt64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(90) * unpackedInt64.size) + unpackedInt64.sumBy(pbandk.Sizer::int64Size)
+    if (unpackedUint32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(91) * unpackedUint32.size) + unpackedUint32.sumBy(pbandk.Sizer::uInt32Size)
+    if (unpackedUint64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(92) * unpackedUint64.size) + unpackedUint64.sumBy(pbandk.Sizer::uInt64Size)
+    if (unpackedSint32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(93) * unpackedSint32.size) + unpackedSint32.sumBy(pbandk.Sizer::sInt32Size)
+    if (unpackedSint64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(94) * unpackedSint64.size) + unpackedSint64.sumBy(pbandk.Sizer::sInt64Size)
+    if (unpackedFixed32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(95) * unpackedFixed32.size) + unpackedFixed32.sumBy(pbandk.Sizer::fixed32Size)
+    if (unpackedFixed64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(96) * unpackedFixed64.size) + unpackedFixed64.sumBy(pbandk.Sizer::fixed64Size)
+    if (unpackedSfixed32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(97) * unpackedSfixed32.size) + unpackedSfixed32.sumBy(pbandk.Sizer::sFixed32Size)
+    if (unpackedSfixed64.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(98) * unpackedSfixed64.size) + unpackedSfixed64.sumBy(pbandk.Sizer::sFixed64Size)
+    if (unpackedFloat.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(99) * unpackedFloat.size) + unpackedFloat.sumBy(pbandk.Sizer::floatSize)
+    if (unpackedDouble.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(100) * unpackedDouble.size) + unpackedDouble.sumBy(pbandk.Sizer::doubleSize)
+    if (unpackedBool.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(101) * unpackedBool.size) + unpackedBool.sumBy(pbandk.Sizer::boolSize)
+    if (unpackedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(102) * unpackedNestedEnum.size) + unpackedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (mapInt32Int32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(56, mapInt32Int32, pbandk.conformance.pb.TestAllTypesProto2::MapInt32Int32Entry)
+    if (mapInt64Int64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(57, mapInt64Int64, pbandk.conformance.pb.TestAllTypesProto2::MapInt64Int64Entry)
+    if (mapUint32Uint32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(58, mapUint32Uint32, pbandk.conformance.pb.TestAllTypesProto2::MapUint32Uint32Entry)
+    if (mapUint64Uint64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(59, mapUint64Uint64, pbandk.conformance.pb.TestAllTypesProto2::MapUint64Uint64Entry)
+    if (mapSint32Sint32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(60, mapSint32Sint32, pbandk.conformance.pb.TestAllTypesProto2::MapSint32Sint32Entry)
+    if (mapSint64Sint64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(61, mapSint64Sint64, pbandk.conformance.pb.TestAllTypesProto2::MapSint64Sint64Entry)
+    if (mapFixed32Fixed32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(62, mapFixed32Fixed32, pbandk.conformance.pb.TestAllTypesProto2::MapFixed32Fixed32Entry)
+    if (mapFixed64Fixed64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(63, mapFixed64Fixed64, pbandk.conformance.pb.TestAllTypesProto2::MapFixed64Fixed64Entry)
+    if (mapSfixed32Sfixed32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(64, mapSfixed32Sfixed32, pbandk.conformance.pb.TestAllTypesProto2::MapSfixed32Sfixed32Entry)
+    if (mapSfixed64Sfixed64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(65, mapSfixed64Sfixed64, pbandk.conformance.pb.TestAllTypesProto2::MapSfixed64Sfixed64Entry)
+    if (mapInt32Float.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(66, mapInt32Float, pbandk.conformance.pb.TestAllTypesProto2::MapInt32FloatEntry)
+    if (mapInt32Double.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(67, mapInt32Double, pbandk.conformance.pb.TestAllTypesProto2::MapInt32DoubleEntry)
+    if (mapBoolBool.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(68, mapBoolBool, pbandk.conformance.pb.TestAllTypesProto2::MapBoolBoolEntry)
+    if (mapStringString.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(69, mapStringString, pbandk.conformance.pb.TestAllTypesProto2::MapStringStringEntry)
+    if (mapStringBytes.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(70, mapStringBytes, pbandk.conformance.pb.TestAllTypesProto2::MapStringBytesEntry)
+    if (mapStringNestedMessage.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(71, mapStringNestedMessage, pbandk.conformance.pb.TestAllTypesProto2::MapStringNestedMessageEntry)
+    if (mapStringForeignMessage.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(72, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignMessageEntry)
+    if (mapStringNestedEnum.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(73, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringNestedEnumEntry)
+    if (mapStringForeignEnum.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(74, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignEnumEntry)
+    if (fieldname1 != null) protoSize += pbandk.Sizer.tagSize(401) + pbandk.Sizer.int32Size(fieldname1)
+    if (fieldName2 != null) protoSize += pbandk.Sizer.tagSize(402) + pbandk.Sizer.int32Size(fieldName2)
+    if (fieldName3 != null) protoSize += pbandk.Sizer.tagSize(403) + pbandk.Sizer.int32Size(fieldName3)
+    if (field_name4 != null) protoSize += pbandk.Sizer.tagSize(404) + pbandk.Sizer.int32Size(field_name4)
+    if (field0name5 != null) protoSize += pbandk.Sizer.tagSize(405) + pbandk.Sizer.int32Size(field0name5)
+    if (field0Name6 != null) protoSize += pbandk.Sizer.tagSize(406) + pbandk.Sizer.int32Size(field0Name6)
+    if (fieldName7 != null) protoSize += pbandk.Sizer.tagSize(407) + pbandk.Sizer.int32Size(fieldName7)
+    if (fieldName8 != null) protoSize += pbandk.Sizer.tagSize(408) + pbandk.Sizer.int32Size(fieldName8)
+    if (fieldName9 != null) protoSize += pbandk.Sizer.tagSize(409) + pbandk.Sizer.int32Size(fieldName9)
+    if (fieldName10 != null) protoSize += pbandk.Sizer.tagSize(410) + pbandk.Sizer.int32Size(fieldName10)
+    if (fIELDNAME11 != null) protoSize += pbandk.Sizer.tagSize(411) + pbandk.Sizer.int32Size(fIELDNAME11)
+    if (fIELDName12 != null) protoSize += pbandk.Sizer.tagSize(412) + pbandk.Sizer.int32Size(fIELDName12)
+    if (_fieldName13 != null) protoSize += pbandk.Sizer.tagSize(413) + pbandk.Sizer.int32Size(_fieldName13)
+    if (_FieldName14 != null) protoSize += pbandk.Sizer.tagSize(414) + pbandk.Sizer.int32Size(_FieldName14)
+    if (field_name15 != null) protoSize += pbandk.Sizer.tagSize(415) + pbandk.Sizer.int32Size(field_name15)
+    if (field_Name16 != null) protoSize += pbandk.Sizer.tagSize(416) + pbandk.Sizer.int32Size(field_Name16)
+    if (fieldName17_ != null) protoSize += pbandk.Sizer.tagSize(417) + pbandk.Sizer.int32Size(fieldName17_)
+    if (fieldName18_ != null) protoSize += pbandk.Sizer.tagSize(418) + pbandk.Sizer.int32Size(fieldName18_)
     when (oneofField) {
-        is TestAllTypesProto2.OneofField.OneofUint32 -> protoSize += pbandk.SizerImpl.tagSize(111) + pbandk.SizerImpl.uInt32Size(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofNestedMessage -> protoSize += pbandk.SizerImpl.tagSize(112) + pbandk.SizerImpl.messageSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofString -> protoSize += pbandk.SizerImpl.tagSize(113) + pbandk.SizerImpl.stringSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofBytes -> protoSize += pbandk.SizerImpl.tagSize(114) + pbandk.SizerImpl.bytesSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofBool -> protoSize += pbandk.SizerImpl.tagSize(115) + pbandk.SizerImpl.boolSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofUint64 -> protoSize += pbandk.SizerImpl.tagSize(116) + pbandk.SizerImpl.uInt64Size(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofFloat -> protoSize += pbandk.SizerImpl.tagSize(117) + pbandk.SizerImpl.floatSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofDouble -> protoSize += pbandk.SizerImpl.tagSize(118) + pbandk.SizerImpl.doubleSize(oneofField.value)
-        is TestAllTypesProto2.OneofField.OneofEnum -> protoSize += pbandk.SizerImpl.tagSize(119) + pbandk.SizerImpl.enumSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofUint32 -> protoSize += pbandk.Sizer.tagSize(111) + pbandk.Sizer.uInt32Size(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofNestedMessage -> protoSize += pbandk.Sizer.tagSize(112) + pbandk.Sizer.messageSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofString -> protoSize += pbandk.Sizer.tagSize(113) + pbandk.Sizer.stringSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofBytes -> protoSize += pbandk.Sizer.tagSize(114) + pbandk.Sizer.bytesSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofBool -> protoSize += pbandk.Sizer.tagSize(115) + pbandk.Sizer.boolSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofUint64 -> protoSize += pbandk.Sizer.tagSize(116) + pbandk.Sizer.uInt64Size(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofFloat -> protoSize += pbandk.Sizer.tagSize(117) + pbandk.Sizer.floatSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofDouble -> protoSize += pbandk.Sizer.tagSize(118) + pbandk.Sizer.doubleSize(oneofField.value)
+        is TestAllTypesProto2.OneofField.OneofEnum -> protoSize += pbandk.Sizer.tagSize(119) + pbandk.Sizer.enumSize(oneofField.value)
     }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
@@ -1462,19 +1462,19 @@ private fun TestAllTypesProto2.protoMarshalImpl(protoMarshal: pbandk.Marshaller)
     if (mapStringForeignMessage.isNotEmpty()) protoMarshal.writeMap(578, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignMessageEntry)
     if (mapStringNestedEnum.isNotEmpty()) protoMarshal.writeMap(586, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringNestedEnumEntry)
     if (mapStringForeignEnum.isNotEmpty()) protoMarshal.writeMap(594, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto2::MapStringForeignEnumEntry)
-    if (packedInt32.isNotEmpty()) protoMarshal.writeTag(602).writePackedRepeated(packedInt32, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
-    if (packedInt64.isNotEmpty()) protoMarshal.writeTag(610).writePackedRepeated(packedInt64, pbandk.SizerImpl::int64Size, protoMarshal::writeInt64)
-    if (packedUint32.isNotEmpty()) protoMarshal.writeTag(618).writePackedRepeated(packedUint32, pbandk.SizerImpl::uInt32Size, protoMarshal::writeUInt32)
-    if (packedUint64.isNotEmpty()) protoMarshal.writeTag(626).writePackedRepeated(packedUint64, pbandk.SizerImpl::uInt64Size, protoMarshal::writeUInt64)
-    if (packedSint32.isNotEmpty()) protoMarshal.writeTag(634).writePackedRepeated(packedSint32, pbandk.SizerImpl::sInt32Size, protoMarshal::writeSInt32)
-    if (packedSint64.isNotEmpty()) protoMarshal.writeTag(642).writePackedRepeated(packedSint64, pbandk.SizerImpl::sInt64Size, protoMarshal::writeSInt64)
-    if (packedFixed32.isNotEmpty()) protoMarshal.writeTag(650).writePackedRepeated(packedFixed32, pbandk.SizerImpl::fixed32Size, protoMarshal::writeFixed32)
-    if (packedFixed64.isNotEmpty()) protoMarshal.writeTag(658).writePackedRepeated(packedFixed64, pbandk.SizerImpl::fixed64Size, protoMarshal::writeFixed64)
-    if (packedSfixed32.isNotEmpty()) protoMarshal.writeTag(666).writePackedRepeated(packedSfixed32, pbandk.SizerImpl::sFixed32Size, protoMarshal::writeSFixed32)
-    if (packedSfixed64.isNotEmpty()) protoMarshal.writeTag(674).writePackedRepeated(packedSfixed64, pbandk.SizerImpl::sFixed64Size, protoMarshal::writeSFixed64)
-    if (packedFloat.isNotEmpty()) protoMarshal.writeTag(682).writePackedRepeated(packedFloat, pbandk.SizerImpl::floatSize, protoMarshal::writeFloat)
-    if (packedDouble.isNotEmpty()) protoMarshal.writeTag(690).writePackedRepeated(packedDouble, pbandk.SizerImpl::doubleSize, protoMarshal::writeDouble)
-    if (packedBool.isNotEmpty()) protoMarshal.writeTag(698).writePackedRepeated(packedBool, pbandk.SizerImpl::boolSize, protoMarshal::writeBool)
+    if (packedInt32.isNotEmpty()) protoMarshal.writeTag(602).writePackedRepeated(packedInt32, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
+    if (packedInt64.isNotEmpty()) protoMarshal.writeTag(610).writePackedRepeated(packedInt64, pbandk.Sizer::int64Size, protoMarshal::writeInt64)
+    if (packedUint32.isNotEmpty()) protoMarshal.writeTag(618).writePackedRepeated(packedUint32, pbandk.Sizer::uInt32Size, protoMarshal::writeUInt32)
+    if (packedUint64.isNotEmpty()) protoMarshal.writeTag(626).writePackedRepeated(packedUint64, pbandk.Sizer::uInt64Size, protoMarshal::writeUInt64)
+    if (packedSint32.isNotEmpty()) protoMarshal.writeTag(634).writePackedRepeated(packedSint32, pbandk.Sizer::sInt32Size, protoMarshal::writeSInt32)
+    if (packedSint64.isNotEmpty()) protoMarshal.writeTag(642).writePackedRepeated(packedSint64, pbandk.Sizer::sInt64Size, protoMarshal::writeSInt64)
+    if (packedFixed32.isNotEmpty()) protoMarshal.writeTag(650).writePackedRepeated(packedFixed32, pbandk.Sizer::fixed32Size, protoMarshal::writeFixed32)
+    if (packedFixed64.isNotEmpty()) protoMarshal.writeTag(658).writePackedRepeated(packedFixed64, pbandk.Sizer::fixed64Size, protoMarshal::writeFixed64)
+    if (packedSfixed32.isNotEmpty()) protoMarshal.writeTag(666).writePackedRepeated(packedSfixed32, pbandk.Sizer::sFixed32Size, protoMarshal::writeSFixed32)
+    if (packedSfixed64.isNotEmpty()) protoMarshal.writeTag(674).writePackedRepeated(packedSfixed64, pbandk.Sizer::sFixed64Size, protoMarshal::writeSFixed64)
+    if (packedFloat.isNotEmpty()) protoMarshal.writeTag(682).writePackedRepeated(packedFloat, pbandk.Sizer::floatSize, protoMarshal::writeFloat)
+    if (packedDouble.isNotEmpty()) protoMarshal.writeTag(690).writePackedRepeated(packedDouble, pbandk.Sizer::doubleSize, protoMarshal::writeDouble)
+    if (packedBool.isNotEmpty()) protoMarshal.writeTag(698).writePackedRepeated(packedBool, pbandk.Sizer::boolSize, protoMarshal::writeBool)
     if (packedNestedEnum.isNotEmpty()) packedNestedEnum.forEach { protoMarshal.writeTag(704).writeEnum(it) }
     if (unpackedInt32.isNotEmpty()) unpackedInt32.forEach { protoMarshal.writeTag(712).writeInt32(it) }
     if (unpackedInt64.isNotEmpty()) unpackedInt64.forEach { protoMarshal.writeTag(720).writeInt64(it) }
@@ -2041,8 +2041,8 @@ private fun TestAllTypesProto2.NestedMessage.protoMergeImpl(plus: TestAllTypesPr
 
 private fun TestAllTypesProto2.NestedMessage.protoSizeImpl(): Int {
     var protoSize = 0
-    if (a != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(a)
-    if (corecursive != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(corecursive)
+    if (a != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(a)
+    if (corecursive != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(corecursive)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2094,8 +2094,8 @@ private fun TestAllTypesProto2.MapInt32Int32Entry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto2.MapInt32Int32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2147,8 +2147,8 @@ private fun TestAllTypesProto2.MapInt64Int64Entry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto2.MapInt64Int64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int64Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int64Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int64Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2200,8 +2200,8 @@ private fun TestAllTypesProto2.MapUint32Uint32Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto2.MapUint32Uint32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.uInt32Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.uInt32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2253,8 +2253,8 @@ private fun TestAllTypesProto2.MapUint64Uint64Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto2.MapUint64Uint64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt64Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.uInt64Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt64Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.uInt64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2306,8 +2306,8 @@ private fun TestAllTypesProto2.MapSint32Sint32Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto2.MapSint32Sint32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sInt32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sInt32Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sInt32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sInt32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2359,8 +2359,8 @@ private fun TestAllTypesProto2.MapSint64Sint64Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto2.MapSint64Sint64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sInt64Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sInt64Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sInt64Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sInt64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2412,8 +2412,8 @@ private fun TestAllTypesProto2.MapFixed32Fixed32Entry.protoMergeImpl(plus: TestA
 
 private fun TestAllTypesProto2.MapFixed32Fixed32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.fixed32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.fixed32Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.fixed32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.fixed32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2465,8 +2465,8 @@ private fun TestAllTypesProto2.MapFixed64Fixed64Entry.protoMergeImpl(plus: TestA
 
 private fun TestAllTypesProto2.MapFixed64Fixed64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.fixed64Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.fixed64Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.fixed64Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.fixed64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2518,8 +2518,8 @@ private fun TestAllTypesProto2.MapSfixed32Sfixed32Entry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto2.MapSfixed32Sfixed32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sFixed32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sFixed32Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sFixed32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sFixed32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2571,8 +2571,8 @@ private fun TestAllTypesProto2.MapSfixed64Sfixed64Entry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto2.MapSfixed64Sfixed64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sFixed64Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sFixed64Size(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sFixed64Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sFixed64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2624,8 +2624,8 @@ private fun TestAllTypesProto2.MapInt32FloatEntry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto2.MapInt32FloatEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.floatSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.floatSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2677,8 +2677,8 @@ private fun TestAllTypesProto2.MapInt32DoubleEntry.protoMergeImpl(plus: TestAllT
 
 private fun TestAllTypesProto2.MapInt32DoubleEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.doubleSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.doubleSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2730,8 +2730,8 @@ private fun TestAllTypesProto2.MapBoolBoolEntry.protoMergeImpl(plus: TestAllType
 
 private fun TestAllTypesProto2.MapBoolBoolEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2783,8 +2783,8 @@ private fun TestAllTypesProto2.MapStringStringEntry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto2.MapStringStringEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2836,8 +2836,8 @@ private fun TestAllTypesProto2.MapStringBytesEntry.protoMergeImpl(plus: TestAllT
 
 private fun TestAllTypesProto2.MapStringBytesEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.bytesSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.bytesSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2889,8 +2889,8 @@ private fun TestAllTypesProto2.MapStringNestedMessageEntry.protoMergeImpl(plus: 
 
 private fun TestAllTypesProto2.MapStringNestedMessageEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2942,8 +2942,8 @@ private fun TestAllTypesProto2.MapStringForeignMessageEntry.protoMergeImpl(plus:
 
 private fun TestAllTypesProto2.MapStringForeignMessageEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2995,8 +2995,8 @@ private fun TestAllTypesProto2.MapStringNestedEnumEntry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto2.MapStringNestedEnumEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.enumSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.enumSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3048,8 +3048,8 @@ private fun TestAllTypesProto2.MapStringForeignEnumEntry.protoMergeImpl(plus: Te
 
 private fun TestAllTypesProto2.MapStringForeignEnumEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.enumSize(value)
+    if (key != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.enumSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3101,8 +3101,8 @@ private fun TestAllTypesProto2.Data.protoMergeImpl(plus: TestAllTypesProto2.Data
 
 private fun TestAllTypesProto2.Data.protoSizeImpl(): Int {
     var protoSize = 0
-    if (groupInt32 != null) protoSize += pbandk.SizerImpl.tagSize(202) + pbandk.SizerImpl.int32Size(groupInt32)
-    if (groupUint32 != null) protoSize += pbandk.SizerImpl.tagSize(203) + pbandk.SizerImpl.uInt32Size(groupUint32)
+    if (groupInt32 != null) protoSize += pbandk.Sizer.tagSize(202) + pbandk.Sizer.int32Size(groupInt32)
+    if (groupUint32 != null) protoSize += pbandk.Sizer.tagSize(203) + pbandk.Sizer.uInt32Size(groupUint32)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3192,7 +3192,7 @@ private fun TestAllTypesProto2.MessageSetCorrectExtension1.protoMergeImpl(plus: 
 
 private fun TestAllTypesProto2.MessageSetCorrectExtension1.protoSizeImpl(): Int {
     var protoSize = 0
-    if (str != null) protoSize += pbandk.SizerImpl.tagSize(25) + pbandk.SizerImpl.stringSize(str)
+    if (str != null) protoSize += pbandk.Sizer.tagSize(25) + pbandk.Sizer.stringSize(str)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3238,7 +3238,7 @@ private fun TestAllTypesProto2.MessageSetCorrectExtension2.protoMergeImpl(plus: 
 
 private fun TestAllTypesProto2.MessageSetCorrectExtension2.protoSizeImpl(): Int {
     var protoSize = 0
-    if (i != null) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.int32Size(i)
+    if (i != null) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.int32Size(i)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3284,7 +3284,7 @@ private fun ForeignMessageProto2.protoMergeImpl(plus: ForeignMessageProto2?): Fo
 
 private fun ForeignMessageProto2.protoSizeImpl(): Int {
     var protoSize = 0
-    if (c != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(c)
+    if (c != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(c)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3334,11 +3334,11 @@ private fun UnknownToTestAllTypes.protoMergeImpl(plus: UnknownToTestAllTypes?): 
 
 private fun UnknownToTestAllTypes.protoSizeImpl(): Int {
     var protoSize = 0
-    if (optionalInt32 != null) protoSize += pbandk.SizerImpl.tagSize(1001) + pbandk.SizerImpl.int32Size(optionalInt32)
-    if (optionalString != null) protoSize += pbandk.SizerImpl.tagSize(1002) + pbandk.SizerImpl.stringSize(optionalString)
-    if (nestedMessage != null) protoSize += pbandk.SizerImpl.tagSize(1003) + pbandk.SizerImpl.messageSize(nestedMessage)
-    if (optionalBool != null) protoSize += pbandk.SizerImpl.tagSize(1006) + pbandk.SizerImpl.boolSize(optionalBool)
-    if (repeatedInt32.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1011) * repeatedInt32.size) + repeatedInt32.sumBy(pbandk.SizerImpl::int32Size)
+    if (optionalInt32 != null) protoSize += pbandk.Sizer.tagSize(1001) + pbandk.Sizer.int32Size(optionalInt32)
+    if (optionalString != null) protoSize += pbandk.Sizer.tagSize(1002) + pbandk.Sizer.stringSize(optionalString)
+    if (nestedMessage != null) protoSize += pbandk.Sizer.tagSize(1003) + pbandk.Sizer.messageSize(nestedMessage)
+    if (optionalBool != null) protoSize += pbandk.Sizer.tagSize(1006) + pbandk.Sizer.boolSize(optionalBool)
+    if (repeatedInt32.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1011) * repeatedInt32.size) + repeatedInt32.sumBy(pbandk.Sizer::int32Size)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3405,7 +3405,7 @@ private fun UnknownToTestAllTypes.OptionalGroup.protoMergeImpl(plus: UnknownToTe
 
 private fun UnknownToTestAllTypes.OptionalGroup.protoSizeImpl(): Int {
     var protoSize = 0
-    if (a != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(a)
+    if (a != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(a)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
@@ -1231,156 +1231,156 @@ private fun TestAllTypesProto3.protoMergeImpl(plus: TestAllTypesProto3?): TestAl
 
 private fun TestAllTypesProto3.protoSizeImpl(): Int {
     var protoSize = 0
-    if (optionalInt32 != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(optionalInt32)
-    if (optionalInt64 != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int64Size(optionalInt64)
-    if (optionalUint32 != 0) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.uInt32Size(optionalUint32)
-    if (optionalUint64 != 0L) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.uInt64Size(optionalUint64)
-    if (optionalSint32 != 0) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.sInt32Size(optionalSint32)
-    if (optionalSint64 != 0L) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.sInt64Size(optionalSint64)
-    if (optionalFixed32 != 0) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.fixed32Size(optionalFixed32)
-    if (optionalFixed64 != 0L) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.fixed64Size(optionalFixed64)
-    if (optionalSfixed32 != 0) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.sFixed32Size(optionalSfixed32)
-    if (optionalSfixed64 != 0L) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.sFixed64Size(optionalSfixed64)
-    if (optionalFloat != 0.0F) protoSize += pbandk.SizerImpl.tagSize(11) + pbandk.SizerImpl.floatSize(optionalFloat)
-    if (optionalDouble != 0.0) protoSize += pbandk.SizerImpl.tagSize(12) + pbandk.SizerImpl.doubleSize(optionalDouble)
-    if (optionalBool) protoSize += pbandk.SizerImpl.tagSize(13) + pbandk.SizerImpl.boolSize(optionalBool)
-    if (optionalString.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(14) + pbandk.SizerImpl.stringSize(optionalString)
-    if (optionalBytes.array.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(15) + pbandk.SizerImpl.bytesSize(optionalBytes)
-    if (optionalNestedMessage != null) protoSize += pbandk.SizerImpl.tagSize(18) + pbandk.SizerImpl.messageSize(optionalNestedMessage)
-    if (optionalForeignMessage != null) protoSize += pbandk.SizerImpl.tagSize(19) + pbandk.SizerImpl.messageSize(optionalForeignMessage)
-    if (optionalNestedEnum.value != 0) protoSize += pbandk.SizerImpl.tagSize(21) + pbandk.SizerImpl.enumSize(optionalNestedEnum)
-    if (optionalForeignEnum.value != 0) protoSize += pbandk.SizerImpl.tagSize(22) + pbandk.SizerImpl.enumSize(optionalForeignEnum)
-    if (optionalAliasedEnum.value != 0) protoSize += pbandk.SizerImpl.tagSize(23) + pbandk.SizerImpl.enumSize(optionalAliasedEnum)
-    if (optionalStringPiece.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(24) + pbandk.SizerImpl.stringSize(optionalStringPiece)
-    if (optionalCord.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(25) + pbandk.SizerImpl.stringSize(optionalCord)
-    if (recursiveMessage != null) protoSize += pbandk.SizerImpl.tagSize(27) + pbandk.SizerImpl.messageSize(recursiveMessage)
-    if (repeatedInt32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(31) + pbandk.SizerImpl.packedRepeatedSize(repeatedInt32, pbandk.SizerImpl::int32Size)
-    if (repeatedInt64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(32) + pbandk.SizerImpl.packedRepeatedSize(repeatedInt64, pbandk.SizerImpl::int64Size)
-    if (repeatedUint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(33) + pbandk.SizerImpl.packedRepeatedSize(repeatedUint32, pbandk.SizerImpl::uInt32Size)
-    if (repeatedUint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(34) + pbandk.SizerImpl.packedRepeatedSize(repeatedUint64, pbandk.SizerImpl::uInt64Size)
-    if (repeatedSint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(35) + pbandk.SizerImpl.packedRepeatedSize(repeatedSint32, pbandk.SizerImpl::sInt32Size)
-    if (repeatedSint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(36) + pbandk.SizerImpl.packedRepeatedSize(repeatedSint64, pbandk.SizerImpl::sInt64Size)
-    if (repeatedFixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(37) + pbandk.SizerImpl.packedRepeatedSize(repeatedFixed32, pbandk.SizerImpl::fixed32Size)
-    if (repeatedFixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(38) + pbandk.SizerImpl.packedRepeatedSize(repeatedFixed64, pbandk.SizerImpl::fixed64Size)
-    if (repeatedSfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(39) + pbandk.SizerImpl.packedRepeatedSize(repeatedSfixed32, pbandk.SizerImpl::sFixed32Size)
-    if (repeatedSfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(40) + pbandk.SizerImpl.packedRepeatedSize(repeatedSfixed64, pbandk.SizerImpl::sFixed64Size)
-    if (repeatedFloat.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(41) + pbandk.SizerImpl.packedRepeatedSize(repeatedFloat, pbandk.SizerImpl::floatSize)
-    if (repeatedDouble.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(42) + pbandk.SizerImpl.packedRepeatedSize(repeatedDouble, pbandk.SizerImpl::doubleSize)
-    if (repeatedBool.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(43) + pbandk.SizerImpl.packedRepeatedSize(repeatedBool, pbandk.SizerImpl::boolSize)
-    if (repeatedString.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(44) * repeatedString.size) + repeatedString.sumBy(pbandk.SizerImpl::stringSize)
-    if (repeatedBytes.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(45) * repeatedBytes.size) + repeatedBytes.sumBy(pbandk.SizerImpl::bytesSize)
-    if (repeatedNestedMessage.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(48) * repeatedNestedMessage.size) + repeatedNestedMessage.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedForeignMessage.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(49) * repeatedForeignMessage.size) + repeatedForeignMessage.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(51) * repeatedNestedEnum.size) + repeatedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (repeatedForeignEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(52) * repeatedForeignEnum.size) + repeatedForeignEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (repeatedStringPiece.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(54) * repeatedStringPiece.size) + repeatedStringPiece.sumBy(pbandk.SizerImpl::stringSize)
-    if (repeatedCord.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(55) * repeatedCord.size) + repeatedCord.sumBy(pbandk.SizerImpl::stringSize)
-    if (packedInt32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(75) + pbandk.SizerImpl.packedRepeatedSize(packedInt32, pbandk.SizerImpl::int32Size)
-    if (packedInt64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(76) + pbandk.SizerImpl.packedRepeatedSize(packedInt64, pbandk.SizerImpl::int64Size)
-    if (packedUint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(77) + pbandk.SizerImpl.packedRepeatedSize(packedUint32, pbandk.SizerImpl::uInt32Size)
-    if (packedUint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(78) + pbandk.SizerImpl.packedRepeatedSize(packedUint64, pbandk.SizerImpl::uInt64Size)
-    if (packedSint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(79) + pbandk.SizerImpl.packedRepeatedSize(packedSint32, pbandk.SizerImpl::sInt32Size)
-    if (packedSint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(80) + pbandk.SizerImpl.packedRepeatedSize(packedSint64, pbandk.SizerImpl::sInt64Size)
-    if (packedFixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(81) + pbandk.SizerImpl.packedRepeatedSize(packedFixed32, pbandk.SizerImpl::fixed32Size)
-    if (packedFixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(82) + pbandk.SizerImpl.packedRepeatedSize(packedFixed64, pbandk.SizerImpl::fixed64Size)
-    if (packedSfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(83) + pbandk.SizerImpl.packedRepeatedSize(packedSfixed32, pbandk.SizerImpl::sFixed32Size)
-    if (packedSfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(84) + pbandk.SizerImpl.packedRepeatedSize(packedSfixed64, pbandk.SizerImpl::sFixed64Size)
-    if (packedFloat.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(85) + pbandk.SizerImpl.packedRepeatedSize(packedFloat, pbandk.SizerImpl::floatSize)
-    if (packedDouble.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(86) + pbandk.SizerImpl.packedRepeatedSize(packedDouble, pbandk.SizerImpl::doubleSize)
-    if (packedBool.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(87) + pbandk.SizerImpl.packedRepeatedSize(packedBool, pbandk.SizerImpl::boolSize)
-    if (packedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(88) * packedNestedEnum.size) + packedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (unpackedInt32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(89) + pbandk.SizerImpl.packedRepeatedSize(unpackedInt32, pbandk.SizerImpl::int32Size)
-    if (unpackedInt64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(90) + pbandk.SizerImpl.packedRepeatedSize(unpackedInt64, pbandk.SizerImpl::int64Size)
-    if (unpackedUint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(91) + pbandk.SizerImpl.packedRepeatedSize(unpackedUint32, pbandk.SizerImpl::uInt32Size)
-    if (unpackedUint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(92) + pbandk.SizerImpl.packedRepeatedSize(unpackedUint64, pbandk.SizerImpl::uInt64Size)
-    if (unpackedSint32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(93) + pbandk.SizerImpl.packedRepeatedSize(unpackedSint32, pbandk.SizerImpl::sInt32Size)
-    if (unpackedSint64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(94) + pbandk.SizerImpl.packedRepeatedSize(unpackedSint64, pbandk.SizerImpl::sInt64Size)
-    if (unpackedFixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(95) + pbandk.SizerImpl.packedRepeatedSize(unpackedFixed32, pbandk.SizerImpl::fixed32Size)
-    if (unpackedFixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(96) + pbandk.SizerImpl.packedRepeatedSize(unpackedFixed64, pbandk.SizerImpl::fixed64Size)
-    if (unpackedSfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(97) + pbandk.SizerImpl.packedRepeatedSize(unpackedSfixed32, pbandk.SizerImpl::sFixed32Size)
-    if (unpackedSfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(98) + pbandk.SizerImpl.packedRepeatedSize(unpackedSfixed64, pbandk.SizerImpl::sFixed64Size)
-    if (unpackedFloat.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(99) + pbandk.SizerImpl.packedRepeatedSize(unpackedFloat, pbandk.SizerImpl::floatSize)
-    if (unpackedDouble.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(100) + pbandk.SizerImpl.packedRepeatedSize(unpackedDouble, pbandk.SizerImpl::doubleSize)
-    if (unpackedBool.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(101) + pbandk.SizerImpl.packedRepeatedSize(unpackedBool, pbandk.SizerImpl::boolSize)
-    if (unpackedNestedEnum.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(102) * unpackedNestedEnum.size) + unpackedNestedEnum.sumBy(pbandk.SizerImpl::enumSize)
-    if (mapInt32Int32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(56, mapInt32Int32, pbandk.conformance.pb.TestAllTypesProto3::MapInt32Int32Entry)
-    if (mapInt64Int64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(57, mapInt64Int64, pbandk.conformance.pb.TestAllTypesProto3::MapInt64Int64Entry)
-    if (mapUint32Uint32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(58, mapUint32Uint32, pbandk.conformance.pb.TestAllTypesProto3::MapUint32Uint32Entry)
-    if (mapUint64Uint64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(59, mapUint64Uint64, pbandk.conformance.pb.TestAllTypesProto3::MapUint64Uint64Entry)
-    if (mapSint32Sint32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(60, mapSint32Sint32, pbandk.conformance.pb.TestAllTypesProto3::MapSint32Sint32Entry)
-    if (mapSint64Sint64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(61, mapSint64Sint64, pbandk.conformance.pb.TestAllTypesProto3::MapSint64Sint64Entry)
-    if (mapFixed32Fixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(62, mapFixed32Fixed32, pbandk.conformance.pb.TestAllTypesProto3::MapFixed32Fixed32Entry)
-    if (mapFixed64Fixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(63, mapFixed64Fixed64, pbandk.conformance.pb.TestAllTypesProto3::MapFixed64Fixed64Entry)
-    if (mapSfixed32Sfixed32.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(64, mapSfixed32Sfixed32, pbandk.conformance.pb.TestAllTypesProto3::MapSfixed32Sfixed32Entry)
-    if (mapSfixed64Sfixed64.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(65, mapSfixed64Sfixed64, pbandk.conformance.pb.TestAllTypesProto3::MapSfixed64Sfixed64Entry)
-    if (mapInt32Float.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(66, mapInt32Float, pbandk.conformance.pb.TestAllTypesProto3::MapInt32FloatEntry)
-    if (mapInt32Double.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(67, mapInt32Double, pbandk.conformance.pb.TestAllTypesProto3::MapInt32DoubleEntry)
-    if (mapBoolBool.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(68, mapBoolBool, pbandk.conformance.pb.TestAllTypesProto3::MapBoolBoolEntry)
-    if (mapStringString.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(69, mapStringString, pbandk.conformance.pb.TestAllTypesProto3::MapStringStringEntry)
-    if (mapStringBytes.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(70, mapStringBytes, pbandk.conformance.pb.TestAllTypesProto3::MapStringBytesEntry)
-    if (mapStringNestedMessage.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(71, mapStringNestedMessage, pbandk.conformance.pb.TestAllTypesProto3::MapStringNestedMessageEntry)
-    if (mapStringForeignMessage.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(72, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignMessageEntry)
-    if (mapStringNestedEnum.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(73, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringNestedEnumEntry)
-    if (mapStringForeignEnum.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(74, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignEnumEntry)
-    if (optionalBoolWrapper != null) protoSize += pbandk.SizerImpl.tagSize(201) + pbandk.SizerImpl.messageSize(pbandk.wkt.BoolValue(optionalBoolWrapper))
-    if (optionalInt32Wrapper != null) protoSize += pbandk.SizerImpl.tagSize(202) + pbandk.SizerImpl.messageSize(pbandk.wkt.Int32Value(optionalInt32Wrapper))
-    if (optionalInt64Wrapper != null) protoSize += pbandk.SizerImpl.tagSize(203) + pbandk.SizerImpl.messageSize(pbandk.wkt.Int64Value(optionalInt64Wrapper))
-    if (optionalUint32Wrapper != null) protoSize += pbandk.SizerImpl.tagSize(204) + pbandk.SizerImpl.messageSize(pbandk.wkt.UInt32Value(optionalUint32Wrapper))
-    if (optionalUint64Wrapper != null) protoSize += pbandk.SizerImpl.tagSize(205) + pbandk.SizerImpl.messageSize(pbandk.wkt.UInt64Value(optionalUint64Wrapper))
-    if (optionalFloatWrapper != null) protoSize += pbandk.SizerImpl.tagSize(206) + pbandk.SizerImpl.messageSize(pbandk.wkt.FloatValue(optionalFloatWrapper))
-    if (optionalDoubleWrapper != null) protoSize += pbandk.SizerImpl.tagSize(207) + pbandk.SizerImpl.messageSize(pbandk.wkt.DoubleValue(optionalDoubleWrapper))
-    if (optionalStringWrapper != null) protoSize += pbandk.SizerImpl.tagSize(208) + pbandk.SizerImpl.messageSize(pbandk.wkt.StringValue(optionalStringWrapper))
-    if (optionalBytesWrapper != null) protoSize += pbandk.SizerImpl.tagSize(209) + pbandk.SizerImpl.messageSize(pbandk.wkt.BytesValue(optionalBytesWrapper))
-    if (repeatedBoolWrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(211) * repeatedBoolWrapper.size) + repeatedBoolWrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.BoolValue(it)) }
-    if (repeatedInt32Wrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(212) * repeatedInt32Wrapper.size) + repeatedInt32Wrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.Int32Value(it)) }
-    if (repeatedInt64Wrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(213) * repeatedInt64Wrapper.size) + repeatedInt64Wrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.Int64Value(it)) }
-    if (repeatedUint32Wrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(214) * repeatedUint32Wrapper.size) + repeatedUint32Wrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.UInt32Value(it)) }
-    if (repeatedUint64Wrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(215) * repeatedUint64Wrapper.size) + repeatedUint64Wrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.UInt64Value(it)) }
-    if (repeatedFloatWrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(216) * repeatedFloatWrapper.size) + repeatedFloatWrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.FloatValue(it)) }
-    if (repeatedDoubleWrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(217) * repeatedDoubleWrapper.size) + repeatedDoubleWrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.DoubleValue(it)) }
-    if (repeatedStringWrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(218) * repeatedStringWrapper.size) + repeatedStringWrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.StringValue(it)) }
-    if (repeatedBytesWrapper.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(219) * repeatedBytesWrapper.size) + repeatedBytesWrapper.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.BytesValue(it)) }
-    if (optionalDuration != null) protoSize += pbandk.SizerImpl.tagSize(301) + pbandk.SizerImpl.messageSize(optionalDuration)
-    if (optionalTimestamp != null) protoSize += pbandk.SizerImpl.tagSize(302) + pbandk.SizerImpl.messageSize(optionalTimestamp)
-    if (optionalFieldMask != null) protoSize += pbandk.SizerImpl.tagSize(303) + pbandk.SizerImpl.messageSize(optionalFieldMask)
-    if (optionalStruct != null) protoSize += pbandk.SizerImpl.tagSize(304) + pbandk.SizerImpl.messageSize(optionalStruct)
-    if (optionalAny != null) protoSize += pbandk.SizerImpl.tagSize(305) + pbandk.SizerImpl.messageSize(optionalAny)
-    if (optionalValue != null) protoSize += pbandk.SizerImpl.tagSize(306) + pbandk.SizerImpl.messageSize(optionalValue)
-    if (repeatedDuration.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(311) * repeatedDuration.size) + repeatedDuration.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedTimestamp.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(312) * repeatedTimestamp.size) + repeatedTimestamp.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedFieldmask.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(313) * repeatedFieldmask.size) + repeatedFieldmask.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedStruct.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(324) * repeatedStruct.size) + repeatedStruct.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedAny.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(315) * repeatedAny.size) + repeatedAny.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedValue.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(316) * repeatedValue.size) + repeatedValue.sumBy(pbandk.SizerImpl::messageSize)
-    if (repeatedListValue.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(317) * repeatedListValue.size) + repeatedListValue.sumBy(pbandk.SizerImpl::messageSize)
-    if (fieldname1 != 0) protoSize += pbandk.SizerImpl.tagSize(401) + pbandk.SizerImpl.int32Size(fieldname1)
-    if (fieldName2 != 0) protoSize += pbandk.SizerImpl.tagSize(402) + pbandk.SizerImpl.int32Size(fieldName2)
-    if (fieldName3 != 0) protoSize += pbandk.SizerImpl.tagSize(403) + pbandk.SizerImpl.int32Size(fieldName3)
-    if (field_name4 != 0) protoSize += pbandk.SizerImpl.tagSize(404) + pbandk.SizerImpl.int32Size(field_name4)
-    if (field0name5 != 0) protoSize += pbandk.SizerImpl.tagSize(405) + pbandk.SizerImpl.int32Size(field0name5)
-    if (field0Name6 != 0) protoSize += pbandk.SizerImpl.tagSize(406) + pbandk.SizerImpl.int32Size(field0Name6)
-    if (fieldName7 != 0) protoSize += pbandk.SizerImpl.tagSize(407) + pbandk.SizerImpl.int32Size(fieldName7)
-    if (fieldName8 != 0) protoSize += pbandk.SizerImpl.tagSize(408) + pbandk.SizerImpl.int32Size(fieldName8)
-    if (fieldName9 != 0) protoSize += pbandk.SizerImpl.tagSize(409) + pbandk.SizerImpl.int32Size(fieldName9)
-    if (fieldName10 != 0) protoSize += pbandk.SizerImpl.tagSize(410) + pbandk.SizerImpl.int32Size(fieldName10)
-    if (fIELDNAME11 != 0) protoSize += pbandk.SizerImpl.tagSize(411) + pbandk.SizerImpl.int32Size(fIELDNAME11)
-    if (fIELDName12 != 0) protoSize += pbandk.SizerImpl.tagSize(412) + pbandk.SizerImpl.int32Size(fIELDName12)
-    if (_fieldName13 != 0) protoSize += pbandk.SizerImpl.tagSize(413) + pbandk.SizerImpl.int32Size(_fieldName13)
-    if (_FieldName14 != 0) protoSize += pbandk.SizerImpl.tagSize(414) + pbandk.SizerImpl.int32Size(_FieldName14)
-    if (field_name15 != 0) protoSize += pbandk.SizerImpl.tagSize(415) + pbandk.SizerImpl.int32Size(field_name15)
-    if (field_Name16 != 0) protoSize += pbandk.SizerImpl.tagSize(416) + pbandk.SizerImpl.int32Size(field_Name16)
-    if (fieldName17_ != 0) protoSize += pbandk.SizerImpl.tagSize(417) + pbandk.SizerImpl.int32Size(fieldName17_)
-    if (fieldName18_ != 0) protoSize += pbandk.SizerImpl.tagSize(418) + pbandk.SizerImpl.int32Size(fieldName18_)
+    if (optionalInt32 != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(optionalInt32)
+    if (optionalInt64 != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int64Size(optionalInt64)
+    if (optionalUint32 != 0) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.uInt32Size(optionalUint32)
+    if (optionalUint64 != 0L) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.uInt64Size(optionalUint64)
+    if (optionalSint32 != 0) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.sInt32Size(optionalSint32)
+    if (optionalSint64 != 0L) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.sInt64Size(optionalSint64)
+    if (optionalFixed32 != 0) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.fixed32Size(optionalFixed32)
+    if (optionalFixed64 != 0L) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.fixed64Size(optionalFixed64)
+    if (optionalSfixed32 != 0) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.sFixed32Size(optionalSfixed32)
+    if (optionalSfixed64 != 0L) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.sFixed64Size(optionalSfixed64)
+    if (optionalFloat != 0.0F) protoSize += pbandk.Sizer.tagSize(11) + pbandk.Sizer.floatSize(optionalFloat)
+    if (optionalDouble != 0.0) protoSize += pbandk.Sizer.tagSize(12) + pbandk.Sizer.doubleSize(optionalDouble)
+    if (optionalBool) protoSize += pbandk.Sizer.tagSize(13) + pbandk.Sizer.boolSize(optionalBool)
+    if (optionalString.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(14) + pbandk.Sizer.stringSize(optionalString)
+    if (optionalBytes.array.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(15) + pbandk.Sizer.bytesSize(optionalBytes)
+    if (optionalNestedMessage != null) protoSize += pbandk.Sizer.tagSize(18) + pbandk.Sizer.messageSize(optionalNestedMessage)
+    if (optionalForeignMessage != null) protoSize += pbandk.Sizer.tagSize(19) + pbandk.Sizer.messageSize(optionalForeignMessage)
+    if (optionalNestedEnum.value != 0) protoSize += pbandk.Sizer.tagSize(21) + pbandk.Sizer.enumSize(optionalNestedEnum)
+    if (optionalForeignEnum.value != 0) protoSize += pbandk.Sizer.tagSize(22) + pbandk.Sizer.enumSize(optionalForeignEnum)
+    if (optionalAliasedEnum.value != 0) protoSize += pbandk.Sizer.tagSize(23) + pbandk.Sizer.enumSize(optionalAliasedEnum)
+    if (optionalStringPiece.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(24) + pbandk.Sizer.stringSize(optionalStringPiece)
+    if (optionalCord.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(25) + pbandk.Sizer.stringSize(optionalCord)
+    if (recursiveMessage != null) protoSize += pbandk.Sizer.tagSize(27) + pbandk.Sizer.messageSize(recursiveMessage)
+    if (repeatedInt32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(31) + pbandk.Sizer.packedRepeatedSize(repeatedInt32, pbandk.Sizer::int32Size)
+    if (repeatedInt64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(32) + pbandk.Sizer.packedRepeatedSize(repeatedInt64, pbandk.Sizer::int64Size)
+    if (repeatedUint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(33) + pbandk.Sizer.packedRepeatedSize(repeatedUint32, pbandk.Sizer::uInt32Size)
+    if (repeatedUint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(34) + pbandk.Sizer.packedRepeatedSize(repeatedUint64, pbandk.Sizer::uInt64Size)
+    if (repeatedSint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(35) + pbandk.Sizer.packedRepeatedSize(repeatedSint32, pbandk.Sizer::sInt32Size)
+    if (repeatedSint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(36) + pbandk.Sizer.packedRepeatedSize(repeatedSint64, pbandk.Sizer::sInt64Size)
+    if (repeatedFixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(37) + pbandk.Sizer.packedRepeatedSize(repeatedFixed32, pbandk.Sizer::fixed32Size)
+    if (repeatedFixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(38) + pbandk.Sizer.packedRepeatedSize(repeatedFixed64, pbandk.Sizer::fixed64Size)
+    if (repeatedSfixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(39) + pbandk.Sizer.packedRepeatedSize(repeatedSfixed32, pbandk.Sizer::sFixed32Size)
+    if (repeatedSfixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(40) + pbandk.Sizer.packedRepeatedSize(repeatedSfixed64, pbandk.Sizer::sFixed64Size)
+    if (repeatedFloat.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(41) + pbandk.Sizer.packedRepeatedSize(repeatedFloat, pbandk.Sizer::floatSize)
+    if (repeatedDouble.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(42) + pbandk.Sizer.packedRepeatedSize(repeatedDouble, pbandk.Sizer::doubleSize)
+    if (repeatedBool.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(43) + pbandk.Sizer.packedRepeatedSize(repeatedBool, pbandk.Sizer::boolSize)
+    if (repeatedString.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(44) * repeatedString.size) + repeatedString.sumBy(pbandk.Sizer::stringSize)
+    if (repeatedBytes.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(45) * repeatedBytes.size) + repeatedBytes.sumBy(pbandk.Sizer::bytesSize)
+    if (repeatedNestedMessage.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(48) * repeatedNestedMessage.size) + repeatedNestedMessage.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedForeignMessage.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(49) * repeatedForeignMessage.size) + repeatedForeignMessage.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(51) * repeatedNestedEnum.size) + repeatedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (repeatedForeignEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(52) * repeatedForeignEnum.size) + repeatedForeignEnum.sumBy(pbandk.Sizer::enumSize)
+    if (repeatedStringPiece.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(54) * repeatedStringPiece.size) + repeatedStringPiece.sumBy(pbandk.Sizer::stringSize)
+    if (repeatedCord.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(55) * repeatedCord.size) + repeatedCord.sumBy(pbandk.Sizer::stringSize)
+    if (packedInt32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(75) + pbandk.Sizer.packedRepeatedSize(packedInt32, pbandk.Sizer::int32Size)
+    if (packedInt64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(76) + pbandk.Sizer.packedRepeatedSize(packedInt64, pbandk.Sizer::int64Size)
+    if (packedUint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(77) + pbandk.Sizer.packedRepeatedSize(packedUint32, pbandk.Sizer::uInt32Size)
+    if (packedUint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(78) + pbandk.Sizer.packedRepeatedSize(packedUint64, pbandk.Sizer::uInt64Size)
+    if (packedSint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(79) + pbandk.Sizer.packedRepeatedSize(packedSint32, pbandk.Sizer::sInt32Size)
+    if (packedSint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(80) + pbandk.Sizer.packedRepeatedSize(packedSint64, pbandk.Sizer::sInt64Size)
+    if (packedFixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(81) + pbandk.Sizer.packedRepeatedSize(packedFixed32, pbandk.Sizer::fixed32Size)
+    if (packedFixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(82) + pbandk.Sizer.packedRepeatedSize(packedFixed64, pbandk.Sizer::fixed64Size)
+    if (packedSfixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(83) + pbandk.Sizer.packedRepeatedSize(packedSfixed32, pbandk.Sizer::sFixed32Size)
+    if (packedSfixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(84) + pbandk.Sizer.packedRepeatedSize(packedSfixed64, pbandk.Sizer::sFixed64Size)
+    if (packedFloat.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(85) + pbandk.Sizer.packedRepeatedSize(packedFloat, pbandk.Sizer::floatSize)
+    if (packedDouble.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(86) + pbandk.Sizer.packedRepeatedSize(packedDouble, pbandk.Sizer::doubleSize)
+    if (packedBool.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(87) + pbandk.Sizer.packedRepeatedSize(packedBool, pbandk.Sizer::boolSize)
+    if (packedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(88) * packedNestedEnum.size) + packedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (unpackedInt32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(89) + pbandk.Sizer.packedRepeatedSize(unpackedInt32, pbandk.Sizer::int32Size)
+    if (unpackedInt64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(90) + pbandk.Sizer.packedRepeatedSize(unpackedInt64, pbandk.Sizer::int64Size)
+    if (unpackedUint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(91) + pbandk.Sizer.packedRepeatedSize(unpackedUint32, pbandk.Sizer::uInt32Size)
+    if (unpackedUint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(92) + pbandk.Sizer.packedRepeatedSize(unpackedUint64, pbandk.Sizer::uInt64Size)
+    if (unpackedSint32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(93) + pbandk.Sizer.packedRepeatedSize(unpackedSint32, pbandk.Sizer::sInt32Size)
+    if (unpackedSint64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(94) + pbandk.Sizer.packedRepeatedSize(unpackedSint64, pbandk.Sizer::sInt64Size)
+    if (unpackedFixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(95) + pbandk.Sizer.packedRepeatedSize(unpackedFixed32, pbandk.Sizer::fixed32Size)
+    if (unpackedFixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(96) + pbandk.Sizer.packedRepeatedSize(unpackedFixed64, pbandk.Sizer::fixed64Size)
+    if (unpackedSfixed32.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(97) + pbandk.Sizer.packedRepeatedSize(unpackedSfixed32, pbandk.Sizer::sFixed32Size)
+    if (unpackedSfixed64.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(98) + pbandk.Sizer.packedRepeatedSize(unpackedSfixed64, pbandk.Sizer::sFixed64Size)
+    if (unpackedFloat.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(99) + pbandk.Sizer.packedRepeatedSize(unpackedFloat, pbandk.Sizer::floatSize)
+    if (unpackedDouble.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(100) + pbandk.Sizer.packedRepeatedSize(unpackedDouble, pbandk.Sizer::doubleSize)
+    if (unpackedBool.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(101) + pbandk.Sizer.packedRepeatedSize(unpackedBool, pbandk.Sizer::boolSize)
+    if (unpackedNestedEnum.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(102) * unpackedNestedEnum.size) + unpackedNestedEnum.sumBy(pbandk.Sizer::enumSize)
+    if (mapInt32Int32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(56, mapInt32Int32, pbandk.conformance.pb.TestAllTypesProto3::MapInt32Int32Entry)
+    if (mapInt64Int64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(57, mapInt64Int64, pbandk.conformance.pb.TestAllTypesProto3::MapInt64Int64Entry)
+    if (mapUint32Uint32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(58, mapUint32Uint32, pbandk.conformance.pb.TestAllTypesProto3::MapUint32Uint32Entry)
+    if (mapUint64Uint64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(59, mapUint64Uint64, pbandk.conformance.pb.TestAllTypesProto3::MapUint64Uint64Entry)
+    if (mapSint32Sint32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(60, mapSint32Sint32, pbandk.conformance.pb.TestAllTypesProto3::MapSint32Sint32Entry)
+    if (mapSint64Sint64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(61, mapSint64Sint64, pbandk.conformance.pb.TestAllTypesProto3::MapSint64Sint64Entry)
+    if (mapFixed32Fixed32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(62, mapFixed32Fixed32, pbandk.conformance.pb.TestAllTypesProto3::MapFixed32Fixed32Entry)
+    if (mapFixed64Fixed64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(63, mapFixed64Fixed64, pbandk.conformance.pb.TestAllTypesProto3::MapFixed64Fixed64Entry)
+    if (mapSfixed32Sfixed32.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(64, mapSfixed32Sfixed32, pbandk.conformance.pb.TestAllTypesProto3::MapSfixed32Sfixed32Entry)
+    if (mapSfixed64Sfixed64.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(65, mapSfixed64Sfixed64, pbandk.conformance.pb.TestAllTypesProto3::MapSfixed64Sfixed64Entry)
+    if (mapInt32Float.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(66, mapInt32Float, pbandk.conformance.pb.TestAllTypesProto3::MapInt32FloatEntry)
+    if (mapInt32Double.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(67, mapInt32Double, pbandk.conformance.pb.TestAllTypesProto3::MapInt32DoubleEntry)
+    if (mapBoolBool.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(68, mapBoolBool, pbandk.conformance.pb.TestAllTypesProto3::MapBoolBoolEntry)
+    if (mapStringString.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(69, mapStringString, pbandk.conformance.pb.TestAllTypesProto3::MapStringStringEntry)
+    if (mapStringBytes.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(70, mapStringBytes, pbandk.conformance.pb.TestAllTypesProto3::MapStringBytesEntry)
+    if (mapStringNestedMessage.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(71, mapStringNestedMessage, pbandk.conformance.pb.TestAllTypesProto3::MapStringNestedMessageEntry)
+    if (mapStringForeignMessage.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(72, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignMessageEntry)
+    if (mapStringNestedEnum.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(73, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringNestedEnumEntry)
+    if (mapStringForeignEnum.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(74, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignEnumEntry)
+    if (optionalBoolWrapper != null) protoSize += pbandk.Sizer.tagSize(201) + pbandk.Sizer.messageSize(pbandk.wkt.BoolValue(optionalBoolWrapper))
+    if (optionalInt32Wrapper != null) protoSize += pbandk.Sizer.tagSize(202) + pbandk.Sizer.messageSize(pbandk.wkt.Int32Value(optionalInt32Wrapper))
+    if (optionalInt64Wrapper != null) protoSize += pbandk.Sizer.tagSize(203) + pbandk.Sizer.messageSize(pbandk.wkt.Int64Value(optionalInt64Wrapper))
+    if (optionalUint32Wrapper != null) protoSize += pbandk.Sizer.tagSize(204) + pbandk.Sizer.messageSize(pbandk.wkt.UInt32Value(optionalUint32Wrapper))
+    if (optionalUint64Wrapper != null) protoSize += pbandk.Sizer.tagSize(205) + pbandk.Sizer.messageSize(pbandk.wkt.UInt64Value(optionalUint64Wrapper))
+    if (optionalFloatWrapper != null) protoSize += pbandk.Sizer.tagSize(206) + pbandk.Sizer.messageSize(pbandk.wkt.FloatValue(optionalFloatWrapper))
+    if (optionalDoubleWrapper != null) protoSize += pbandk.Sizer.tagSize(207) + pbandk.Sizer.messageSize(pbandk.wkt.DoubleValue(optionalDoubleWrapper))
+    if (optionalStringWrapper != null) protoSize += pbandk.Sizer.tagSize(208) + pbandk.Sizer.messageSize(pbandk.wkt.StringValue(optionalStringWrapper))
+    if (optionalBytesWrapper != null) protoSize += pbandk.Sizer.tagSize(209) + pbandk.Sizer.messageSize(pbandk.wkt.BytesValue(optionalBytesWrapper))
+    if (repeatedBoolWrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(211) * repeatedBoolWrapper.size) + repeatedBoolWrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.BoolValue(it)) }
+    if (repeatedInt32Wrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(212) * repeatedInt32Wrapper.size) + repeatedInt32Wrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.Int32Value(it)) }
+    if (repeatedInt64Wrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(213) * repeatedInt64Wrapper.size) + repeatedInt64Wrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.Int64Value(it)) }
+    if (repeatedUint32Wrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(214) * repeatedUint32Wrapper.size) + repeatedUint32Wrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.UInt32Value(it)) }
+    if (repeatedUint64Wrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(215) * repeatedUint64Wrapper.size) + repeatedUint64Wrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.UInt64Value(it)) }
+    if (repeatedFloatWrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(216) * repeatedFloatWrapper.size) + repeatedFloatWrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.FloatValue(it)) }
+    if (repeatedDoubleWrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(217) * repeatedDoubleWrapper.size) + repeatedDoubleWrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.DoubleValue(it)) }
+    if (repeatedStringWrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(218) * repeatedStringWrapper.size) + repeatedStringWrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.StringValue(it)) }
+    if (repeatedBytesWrapper.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(219) * repeatedBytesWrapper.size) + repeatedBytesWrapper.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.BytesValue(it)) }
+    if (optionalDuration != null) protoSize += pbandk.Sizer.tagSize(301) + pbandk.Sizer.messageSize(optionalDuration)
+    if (optionalTimestamp != null) protoSize += pbandk.Sizer.tagSize(302) + pbandk.Sizer.messageSize(optionalTimestamp)
+    if (optionalFieldMask != null) protoSize += pbandk.Sizer.tagSize(303) + pbandk.Sizer.messageSize(optionalFieldMask)
+    if (optionalStruct != null) protoSize += pbandk.Sizer.tagSize(304) + pbandk.Sizer.messageSize(optionalStruct)
+    if (optionalAny != null) protoSize += pbandk.Sizer.tagSize(305) + pbandk.Sizer.messageSize(optionalAny)
+    if (optionalValue != null) protoSize += pbandk.Sizer.tagSize(306) + pbandk.Sizer.messageSize(optionalValue)
+    if (repeatedDuration.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(311) * repeatedDuration.size) + repeatedDuration.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedTimestamp.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(312) * repeatedTimestamp.size) + repeatedTimestamp.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedFieldmask.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(313) * repeatedFieldmask.size) + repeatedFieldmask.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedStruct.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(324) * repeatedStruct.size) + repeatedStruct.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedAny.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(315) * repeatedAny.size) + repeatedAny.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedValue.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(316) * repeatedValue.size) + repeatedValue.sumBy(pbandk.Sizer::messageSize)
+    if (repeatedListValue.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(317) * repeatedListValue.size) + repeatedListValue.sumBy(pbandk.Sizer::messageSize)
+    if (fieldname1 != 0) protoSize += pbandk.Sizer.tagSize(401) + pbandk.Sizer.int32Size(fieldname1)
+    if (fieldName2 != 0) protoSize += pbandk.Sizer.tagSize(402) + pbandk.Sizer.int32Size(fieldName2)
+    if (fieldName3 != 0) protoSize += pbandk.Sizer.tagSize(403) + pbandk.Sizer.int32Size(fieldName3)
+    if (field_name4 != 0) protoSize += pbandk.Sizer.tagSize(404) + pbandk.Sizer.int32Size(field_name4)
+    if (field0name5 != 0) protoSize += pbandk.Sizer.tagSize(405) + pbandk.Sizer.int32Size(field0name5)
+    if (field0Name6 != 0) protoSize += pbandk.Sizer.tagSize(406) + pbandk.Sizer.int32Size(field0Name6)
+    if (fieldName7 != 0) protoSize += pbandk.Sizer.tagSize(407) + pbandk.Sizer.int32Size(fieldName7)
+    if (fieldName8 != 0) protoSize += pbandk.Sizer.tagSize(408) + pbandk.Sizer.int32Size(fieldName8)
+    if (fieldName9 != 0) protoSize += pbandk.Sizer.tagSize(409) + pbandk.Sizer.int32Size(fieldName9)
+    if (fieldName10 != 0) protoSize += pbandk.Sizer.tagSize(410) + pbandk.Sizer.int32Size(fieldName10)
+    if (fIELDNAME11 != 0) protoSize += pbandk.Sizer.tagSize(411) + pbandk.Sizer.int32Size(fIELDNAME11)
+    if (fIELDName12 != 0) protoSize += pbandk.Sizer.tagSize(412) + pbandk.Sizer.int32Size(fIELDName12)
+    if (_fieldName13 != 0) protoSize += pbandk.Sizer.tagSize(413) + pbandk.Sizer.int32Size(_fieldName13)
+    if (_FieldName14 != 0) protoSize += pbandk.Sizer.tagSize(414) + pbandk.Sizer.int32Size(_FieldName14)
+    if (field_name15 != 0) protoSize += pbandk.Sizer.tagSize(415) + pbandk.Sizer.int32Size(field_name15)
+    if (field_Name16 != 0) protoSize += pbandk.Sizer.tagSize(416) + pbandk.Sizer.int32Size(field_Name16)
+    if (fieldName17_ != 0) protoSize += pbandk.Sizer.tagSize(417) + pbandk.Sizer.int32Size(fieldName17_)
+    if (fieldName18_ != 0) protoSize += pbandk.Sizer.tagSize(418) + pbandk.Sizer.int32Size(fieldName18_)
     when (oneofField) {
-        is TestAllTypesProto3.OneofField.OneofUint32 -> protoSize += pbandk.SizerImpl.tagSize(111) + pbandk.SizerImpl.uInt32Size(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofNestedMessage -> protoSize += pbandk.SizerImpl.tagSize(112) + pbandk.SizerImpl.messageSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofString -> protoSize += pbandk.SizerImpl.tagSize(113) + pbandk.SizerImpl.stringSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofBytes -> protoSize += pbandk.SizerImpl.tagSize(114) + pbandk.SizerImpl.bytesSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofBool -> protoSize += pbandk.SizerImpl.tagSize(115) + pbandk.SizerImpl.boolSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofUint64 -> protoSize += pbandk.SizerImpl.tagSize(116) + pbandk.SizerImpl.uInt64Size(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofFloat -> protoSize += pbandk.SizerImpl.tagSize(117) + pbandk.SizerImpl.floatSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofDouble -> protoSize += pbandk.SizerImpl.tagSize(118) + pbandk.SizerImpl.doubleSize(oneofField.value)
-        is TestAllTypesProto3.OneofField.OneofEnum -> protoSize += pbandk.SizerImpl.tagSize(119) + pbandk.SizerImpl.enumSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofUint32 -> protoSize += pbandk.Sizer.tagSize(111) + pbandk.Sizer.uInt32Size(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofNestedMessage -> protoSize += pbandk.Sizer.tagSize(112) + pbandk.Sizer.messageSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofString -> protoSize += pbandk.Sizer.tagSize(113) + pbandk.Sizer.stringSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofBytes -> protoSize += pbandk.Sizer.tagSize(114) + pbandk.Sizer.bytesSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofBool -> protoSize += pbandk.Sizer.tagSize(115) + pbandk.Sizer.boolSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofUint64 -> protoSize += pbandk.Sizer.tagSize(116) + pbandk.Sizer.uInt64Size(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofFloat -> protoSize += pbandk.Sizer.tagSize(117) + pbandk.Sizer.floatSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofDouble -> protoSize += pbandk.Sizer.tagSize(118) + pbandk.Sizer.doubleSize(oneofField.value)
+        is TestAllTypesProto3.OneofField.OneofEnum -> protoSize += pbandk.Sizer.tagSize(119) + pbandk.Sizer.enumSize(oneofField.value)
     }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
@@ -1410,19 +1410,19 @@ private fun TestAllTypesProto3.protoMarshalImpl(protoMarshal: pbandk.Marshaller)
     if (optionalStringPiece.isNotEmpty()) protoMarshal.writeTag(194).writeString(optionalStringPiece)
     if (optionalCord.isNotEmpty()) protoMarshal.writeTag(202).writeString(optionalCord)
     if (recursiveMessage != null) protoMarshal.writeTag(218).writeMessage(recursiveMessage)
-    if (repeatedInt32.isNotEmpty()) protoMarshal.writeTag(250).writePackedRepeated(repeatedInt32, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
-    if (repeatedInt64.isNotEmpty()) protoMarshal.writeTag(258).writePackedRepeated(repeatedInt64, pbandk.SizerImpl::int64Size, protoMarshal::writeInt64)
-    if (repeatedUint32.isNotEmpty()) protoMarshal.writeTag(266).writePackedRepeated(repeatedUint32, pbandk.SizerImpl::uInt32Size, protoMarshal::writeUInt32)
-    if (repeatedUint64.isNotEmpty()) protoMarshal.writeTag(274).writePackedRepeated(repeatedUint64, pbandk.SizerImpl::uInt64Size, protoMarshal::writeUInt64)
-    if (repeatedSint32.isNotEmpty()) protoMarshal.writeTag(282).writePackedRepeated(repeatedSint32, pbandk.SizerImpl::sInt32Size, protoMarshal::writeSInt32)
-    if (repeatedSint64.isNotEmpty()) protoMarshal.writeTag(290).writePackedRepeated(repeatedSint64, pbandk.SizerImpl::sInt64Size, protoMarshal::writeSInt64)
-    if (repeatedFixed32.isNotEmpty()) protoMarshal.writeTag(298).writePackedRepeated(repeatedFixed32, pbandk.SizerImpl::fixed32Size, protoMarshal::writeFixed32)
-    if (repeatedFixed64.isNotEmpty()) protoMarshal.writeTag(306).writePackedRepeated(repeatedFixed64, pbandk.SizerImpl::fixed64Size, protoMarshal::writeFixed64)
-    if (repeatedSfixed32.isNotEmpty()) protoMarshal.writeTag(314).writePackedRepeated(repeatedSfixed32, pbandk.SizerImpl::sFixed32Size, protoMarshal::writeSFixed32)
-    if (repeatedSfixed64.isNotEmpty()) protoMarshal.writeTag(322).writePackedRepeated(repeatedSfixed64, pbandk.SizerImpl::sFixed64Size, protoMarshal::writeSFixed64)
-    if (repeatedFloat.isNotEmpty()) protoMarshal.writeTag(330).writePackedRepeated(repeatedFloat, pbandk.SizerImpl::floatSize, protoMarshal::writeFloat)
-    if (repeatedDouble.isNotEmpty()) protoMarshal.writeTag(338).writePackedRepeated(repeatedDouble, pbandk.SizerImpl::doubleSize, protoMarshal::writeDouble)
-    if (repeatedBool.isNotEmpty()) protoMarshal.writeTag(346).writePackedRepeated(repeatedBool, pbandk.SizerImpl::boolSize, protoMarshal::writeBool)
+    if (repeatedInt32.isNotEmpty()) protoMarshal.writeTag(250).writePackedRepeated(repeatedInt32, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
+    if (repeatedInt64.isNotEmpty()) protoMarshal.writeTag(258).writePackedRepeated(repeatedInt64, pbandk.Sizer::int64Size, protoMarshal::writeInt64)
+    if (repeatedUint32.isNotEmpty()) protoMarshal.writeTag(266).writePackedRepeated(repeatedUint32, pbandk.Sizer::uInt32Size, protoMarshal::writeUInt32)
+    if (repeatedUint64.isNotEmpty()) protoMarshal.writeTag(274).writePackedRepeated(repeatedUint64, pbandk.Sizer::uInt64Size, protoMarshal::writeUInt64)
+    if (repeatedSint32.isNotEmpty()) protoMarshal.writeTag(282).writePackedRepeated(repeatedSint32, pbandk.Sizer::sInt32Size, protoMarshal::writeSInt32)
+    if (repeatedSint64.isNotEmpty()) protoMarshal.writeTag(290).writePackedRepeated(repeatedSint64, pbandk.Sizer::sInt64Size, protoMarshal::writeSInt64)
+    if (repeatedFixed32.isNotEmpty()) protoMarshal.writeTag(298).writePackedRepeated(repeatedFixed32, pbandk.Sizer::fixed32Size, protoMarshal::writeFixed32)
+    if (repeatedFixed64.isNotEmpty()) protoMarshal.writeTag(306).writePackedRepeated(repeatedFixed64, pbandk.Sizer::fixed64Size, protoMarshal::writeFixed64)
+    if (repeatedSfixed32.isNotEmpty()) protoMarshal.writeTag(314).writePackedRepeated(repeatedSfixed32, pbandk.Sizer::sFixed32Size, protoMarshal::writeSFixed32)
+    if (repeatedSfixed64.isNotEmpty()) protoMarshal.writeTag(322).writePackedRepeated(repeatedSfixed64, pbandk.Sizer::sFixed64Size, protoMarshal::writeSFixed64)
+    if (repeatedFloat.isNotEmpty()) protoMarshal.writeTag(330).writePackedRepeated(repeatedFloat, pbandk.Sizer::floatSize, protoMarshal::writeFloat)
+    if (repeatedDouble.isNotEmpty()) protoMarshal.writeTag(338).writePackedRepeated(repeatedDouble, pbandk.Sizer::doubleSize, protoMarshal::writeDouble)
+    if (repeatedBool.isNotEmpty()) protoMarshal.writeTag(346).writePackedRepeated(repeatedBool, pbandk.Sizer::boolSize, protoMarshal::writeBool)
     if (repeatedString.isNotEmpty()) repeatedString.forEach { protoMarshal.writeTag(354).writeString(it) }
     if (repeatedBytes.isNotEmpty()) repeatedBytes.forEach { protoMarshal.writeTag(362).writeBytes(it) }
     if (repeatedNestedMessage.isNotEmpty()) repeatedNestedMessage.forEach { protoMarshal.writeTag(386).writeMessage(it) }
@@ -1450,33 +1450,33 @@ private fun TestAllTypesProto3.protoMarshalImpl(protoMarshal: pbandk.Marshaller)
     if (mapStringForeignMessage.isNotEmpty()) protoMarshal.writeMap(578, mapStringForeignMessage, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignMessageEntry)
     if (mapStringNestedEnum.isNotEmpty()) protoMarshal.writeMap(586, mapStringNestedEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringNestedEnumEntry)
     if (mapStringForeignEnum.isNotEmpty()) protoMarshal.writeMap(594, mapStringForeignEnum, pbandk.conformance.pb.TestAllTypesProto3::MapStringForeignEnumEntry)
-    if (packedInt32.isNotEmpty()) protoMarshal.writeTag(602).writePackedRepeated(packedInt32, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
-    if (packedInt64.isNotEmpty()) protoMarshal.writeTag(610).writePackedRepeated(packedInt64, pbandk.SizerImpl::int64Size, protoMarshal::writeInt64)
-    if (packedUint32.isNotEmpty()) protoMarshal.writeTag(618).writePackedRepeated(packedUint32, pbandk.SizerImpl::uInt32Size, protoMarshal::writeUInt32)
-    if (packedUint64.isNotEmpty()) protoMarshal.writeTag(626).writePackedRepeated(packedUint64, pbandk.SizerImpl::uInt64Size, protoMarshal::writeUInt64)
-    if (packedSint32.isNotEmpty()) protoMarshal.writeTag(634).writePackedRepeated(packedSint32, pbandk.SizerImpl::sInt32Size, protoMarshal::writeSInt32)
-    if (packedSint64.isNotEmpty()) protoMarshal.writeTag(642).writePackedRepeated(packedSint64, pbandk.SizerImpl::sInt64Size, protoMarshal::writeSInt64)
-    if (packedFixed32.isNotEmpty()) protoMarshal.writeTag(650).writePackedRepeated(packedFixed32, pbandk.SizerImpl::fixed32Size, protoMarshal::writeFixed32)
-    if (packedFixed64.isNotEmpty()) protoMarshal.writeTag(658).writePackedRepeated(packedFixed64, pbandk.SizerImpl::fixed64Size, protoMarshal::writeFixed64)
-    if (packedSfixed32.isNotEmpty()) protoMarshal.writeTag(666).writePackedRepeated(packedSfixed32, pbandk.SizerImpl::sFixed32Size, protoMarshal::writeSFixed32)
-    if (packedSfixed64.isNotEmpty()) protoMarshal.writeTag(674).writePackedRepeated(packedSfixed64, pbandk.SizerImpl::sFixed64Size, protoMarshal::writeSFixed64)
-    if (packedFloat.isNotEmpty()) protoMarshal.writeTag(682).writePackedRepeated(packedFloat, pbandk.SizerImpl::floatSize, protoMarshal::writeFloat)
-    if (packedDouble.isNotEmpty()) protoMarshal.writeTag(690).writePackedRepeated(packedDouble, pbandk.SizerImpl::doubleSize, protoMarshal::writeDouble)
-    if (packedBool.isNotEmpty()) protoMarshal.writeTag(698).writePackedRepeated(packedBool, pbandk.SizerImpl::boolSize, protoMarshal::writeBool)
+    if (packedInt32.isNotEmpty()) protoMarshal.writeTag(602).writePackedRepeated(packedInt32, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
+    if (packedInt64.isNotEmpty()) protoMarshal.writeTag(610).writePackedRepeated(packedInt64, pbandk.Sizer::int64Size, protoMarshal::writeInt64)
+    if (packedUint32.isNotEmpty()) protoMarshal.writeTag(618).writePackedRepeated(packedUint32, pbandk.Sizer::uInt32Size, protoMarshal::writeUInt32)
+    if (packedUint64.isNotEmpty()) protoMarshal.writeTag(626).writePackedRepeated(packedUint64, pbandk.Sizer::uInt64Size, protoMarshal::writeUInt64)
+    if (packedSint32.isNotEmpty()) protoMarshal.writeTag(634).writePackedRepeated(packedSint32, pbandk.Sizer::sInt32Size, protoMarshal::writeSInt32)
+    if (packedSint64.isNotEmpty()) protoMarshal.writeTag(642).writePackedRepeated(packedSint64, pbandk.Sizer::sInt64Size, protoMarshal::writeSInt64)
+    if (packedFixed32.isNotEmpty()) protoMarshal.writeTag(650).writePackedRepeated(packedFixed32, pbandk.Sizer::fixed32Size, protoMarshal::writeFixed32)
+    if (packedFixed64.isNotEmpty()) protoMarshal.writeTag(658).writePackedRepeated(packedFixed64, pbandk.Sizer::fixed64Size, protoMarshal::writeFixed64)
+    if (packedSfixed32.isNotEmpty()) protoMarshal.writeTag(666).writePackedRepeated(packedSfixed32, pbandk.Sizer::sFixed32Size, protoMarshal::writeSFixed32)
+    if (packedSfixed64.isNotEmpty()) protoMarshal.writeTag(674).writePackedRepeated(packedSfixed64, pbandk.Sizer::sFixed64Size, protoMarshal::writeSFixed64)
+    if (packedFloat.isNotEmpty()) protoMarshal.writeTag(682).writePackedRepeated(packedFloat, pbandk.Sizer::floatSize, protoMarshal::writeFloat)
+    if (packedDouble.isNotEmpty()) protoMarshal.writeTag(690).writePackedRepeated(packedDouble, pbandk.Sizer::doubleSize, protoMarshal::writeDouble)
+    if (packedBool.isNotEmpty()) protoMarshal.writeTag(698).writePackedRepeated(packedBool, pbandk.Sizer::boolSize, protoMarshal::writeBool)
     if (packedNestedEnum.isNotEmpty()) packedNestedEnum.forEach { protoMarshal.writeTag(704).writeEnum(it) }
-    if (unpackedInt32.isNotEmpty()) protoMarshal.writeTag(714).writePackedRepeated(unpackedInt32, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
-    if (unpackedInt64.isNotEmpty()) protoMarshal.writeTag(722).writePackedRepeated(unpackedInt64, pbandk.SizerImpl::int64Size, protoMarshal::writeInt64)
-    if (unpackedUint32.isNotEmpty()) protoMarshal.writeTag(730).writePackedRepeated(unpackedUint32, pbandk.SizerImpl::uInt32Size, protoMarshal::writeUInt32)
-    if (unpackedUint64.isNotEmpty()) protoMarshal.writeTag(738).writePackedRepeated(unpackedUint64, pbandk.SizerImpl::uInt64Size, protoMarshal::writeUInt64)
-    if (unpackedSint32.isNotEmpty()) protoMarshal.writeTag(746).writePackedRepeated(unpackedSint32, pbandk.SizerImpl::sInt32Size, protoMarshal::writeSInt32)
-    if (unpackedSint64.isNotEmpty()) protoMarshal.writeTag(754).writePackedRepeated(unpackedSint64, pbandk.SizerImpl::sInt64Size, protoMarshal::writeSInt64)
-    if (unpackedFixed32.isNotEmpty()) protoMarshal.writeTag(762).writePackedRepeated(unpackedFixed32, pbandk.SizerImpl::fixed32Size, protoMarshal::writeFixed32)
-    if (unpackedFixed64.isNotEmpty()) protoMarshal.writeTag(770).writePackedRepeated(unpackedFixed64, pbandk.SizerImpl::fixed64Size, protoMarshal::writeFixed64)
-    if (unpackedSfixed32.isNotEmpty()) protoMarshal.writeTag(778).writePackedRepeated(unpackedSfixed32, pbandk.SizerImpl::sFixed32Size, protoMarshal::writeSFixed32)
-    if (unpackedSfixed64.isNotEmpty()) protoMarshal.writeTag(786).writePackedRepeated(unpackedSfixed64, pbandk.SizerImpl::sFixed64Size, protoMarshal::writeSFixed64)
-    if (unpackedFloat.isNotEmpty()) protoMarshal.writeTag(794).writePackedRepeated(unpackedFloat, pbandk.SizerImpl::floatSize, protoMarshal::writeFloat)
-    if (unpackedDouble.isNotEmpty()) protoMarshal.writeTag(802).writePackedRepeated(unpackedDouble, pbandk.SizerImpl::doubleSize, protoMarshal::writeDouble)
-    if (unpackedBool.isNotEmpty()) protoMarshal.writeTag(810).writePackedRepeated(unpackedBool, pbandk.SizerImpl::boolSize, protoMarshal::writeBool)
+    if (unpackedInt32.isNotEmpty()) protoMarshal.writeTag(714).writePackedRepeated(unpackedInt32, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
+    if (unpackedInt64.isNotEmpty()) protoMarshal.writeTag(722).writePackedRepeated(unpackedInt64, pbandk.Sizer::int64Size, protoMarshal::writeInt64)
+    if (unpackedUint32.isNotEmpty()) protoMarshal.writeTag(730).writePackedRepeated(unpackedUint32, pbandk.Sizer::uInt32Size, protoMarshal::writeUInt32)
+    if (unpackedUint64.isNotEmpty()) protoMarshal.writeTag(738).writePackedRepeated(unpackedUint64, pbandk.Sizer::uInt64Size, protoMarshal::writeUInt64)
+    if (unpackedSint32.isNotEmpty()) protoMarshal.writeTag(746).writePackedRepeated(unpackedSint32, pbandk.Sizer::sInt32Size, protoMarshal::writeSInt32)
+    if (unpackedSint64.isNotEmpty()) protoMarshal.writeTag(754).writePackedRepeated(unpackedSint64, pbandk.Sizer::sInt64Size, protoMarshal::writeSInt64)
+    if (unpackedFixed32.isNotEmpty()) protoMarshal.writeTag(762).writePackedRepeated(unpackedFixed32, pbandk.Sizer::fixed32Size, protoMarshal::writeFixed32)
+    if (unpackedFixed64.isNotEmpty()) protoMarshal.writeTag(770).writePackedRepeated(unpackedFixed64, pbandk.Sizer::fixed64Size, protoMarshal::writeFixed64)
+    if (unpackedSfixed32.isNotEmpty()) protoMarshal.writeTag(778).writePackedRepeated(unpackedSfixed32, pbandk.Sizer::sFixed32Size, protoMarshal::writeSFixed32)
+    if (unpackedSfixed64.isNotEmpty()) protoMarshal.writeTag(786).writePackedRepeated(unpackedSfixed64, pbandk.Sizer::sFixed64Size, protoMarshal::writeSFixed64)
+    if (unpackedFloat.isNotEmpty()) protoMarshal.writeTag(794).writePackedRepeated(unpackedFloat, pbandk.Sizer::floatSize, protoMarshal::writeFloat)
+    if (unpackedDouble.isNotEmpty()) protoMarshal.writeTag(802).writePackedRepeated(unpackedDouble, pbandk.Sizer::doubleSize, protoMarshal::writeDouble)
+    if (unpackedBool.isNotEmpty()) protoMarshal.writeTag(810).writePackedRepeated(unpackedBool, pbandk.Sizer::boolSize, protoMarshal::writeBool)
     if (unpackedNestedEnum.isNotEmpty()) unpackedNestedEnum.forEach { protoMarshal.writeTag(816).writeEnum(it) }
     if (oneofField is TestAllTypesProto3.OneofField.OneofUint32) protoMarshal.writeTag(888).writeUInt32(oneofField.value)
     if (oneofField is TestAllTypesProto3.OneofField.OneofNestedMessage) protoMarshal.writeTag(898).writeMessage(oneofField.value)
@@ -2195,8 +2195,8 @@ private fun TestAllTypesProto3.NestedMessage.protoMergeImpl(plus: TestAllTypesPr
 
 private fun TestAllTypesProto3.NestedMessage.protoSizeImpl(): Int {
     var protoSize = 0
-    if (a != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(a)
-    if (corecursive != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(corecursive)
+    if (a != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(a)
+    if (corecursive != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(corecursive)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2246,8 +2246,8 @@ private fun TestAllTypesProto3.MapInt32Int32Entry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto3.MapInt32Int32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2297,8 +2297,8 @@ private fun TestAllTypesProto3.MapInt64Int64Entry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto3.MapInt64Int64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int64Size(key)
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int64Size(value)
+    if (key != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int64Size(key)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2348,8 +2348,8 @@ private fun TestAllTypesProto3.MapUint32Uint32Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto3.MapUint32Uint32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt32Size(key)
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.uInt32Size(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt32Size(key)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.uInt32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2399,8 +2399,8 @@ private fun TestAllTypesProto3.MapUint64Uint64Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto3.MapUint64Uint64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt64Size(key)
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.uInt64Size(value)
+    if (key != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt64Size(key)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.uInt64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2450,8 +2450,8 @@ private fun TestAllTypesProto3.MapSint32Sint32Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto3.MapSint32Sint32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sInt32Size(key)
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sInt32Size(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sInt32Size(key)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sInt32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2501,8 +2501,8 @@ private fun TestAllTypesProto3.MapSint64Sint64Entry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto3.MapSint64Sint64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sInt64Size(key)
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sInt64Size(value)
+    if (key != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sInt64Size(key)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sInt64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2552,8 +2552,8 @@ private fun TestAllTypesProto3.MapFixed32Fixed32Entry.protoMergeImpl(plus: TestA
 
 private fun TestAllTypesProto3.MapFixed32Fixed32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.fixed32Size(key)
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.fixed32Size(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.fixed32Size(key)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.fixed32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2603,8 +2603,8 @@ private fun TestAllTypesProto3.MapFixed64Fixed64Entry.protoMergeImpl(plus: TestA
 
 private fun TestAllTypesProto3.MapFixed64Fixed64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.fixed64Size(key)
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.fixed64Size(value)
+    if (key != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.fixed64Size(key)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.fixed64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2654,8 +2654,8 @@ private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sFixed32Size(key)
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sFixed32Size(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sFixed32Size(key)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sFixed32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2705,8 +2705,8 @@ private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.sFixed64Size(key)
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.sFixed64Size(value)
+    if (key != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.sFixed64Size(key)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.sFixed64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2756,8 +2756,8 @@ private fun TestAllTypesProto3.MapInt32FloatEntry.protoMergeImpl(plus: TestAllTy
 
 private fun TestAllTypesProto3.MapInt32FloatEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != 0.0F) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.floatSize(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != 0.0F) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.floatSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2807,8 +2807,8 @@ private fun TestAllTypesProto3.MapInt32DoubleEntry.protoMergeImpl(plus: TestAllT
 
 private fun TestAllTypesProto3.MapInt32DoubleEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(key)
-    if (value != 0.0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.doubleSize(value)
+    if (key != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(key)
+    if (value != 0.0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.doubleSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2858,8 +2858,8 @@ private fun TestAllTypesProto3.MapBoolBoolEntry.protoMergeImpl(plus: TestAllType
 
 private fun TestAllTypesProto3.MapBoolBoolEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(key)
-    if (value) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(value)
+    if (key) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(key)
+    if (value) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2909,8 +2909,8 @@ private fun TestAllTypesProto3.MapStringStringEntry.protoMergeImpl(plus: TestAll
 
 private fun TestAllTypesProto3.MapStringStringEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2960,8 +2960,8 @@ private fun TestAllTypesProto3.MapStringBytesEntry.protoMergeImpl(plus: TestAllT
 
 private fun TestAllTypesProto3.MapStringBytesEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value.array.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.bytesSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.array.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.bytesSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3012,8 +3012,8 @@ private fun TestAllTypesProto3.MapStringNestedMessageEntry.protoMergeImpl(plus: 
 
 private fun TestAllTypesProto3.MapStringNestedMessageEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3064,8 +3064,8 @@ private fun TestAllTypesProto3.MapStringForeignMessageEntry.protoMergeImpl(plus:
 
 private fun TestAllTypesProto3.MapStringForeignMessageEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3115,8 +3115,8 @@ private fun TestAllTypesProto3.MapStringNestedEnumEntry.protoMergeImpl(plus: Tes
 
 private fun TestAllTypesProto3.MapStringNestedEnumEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value.value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.enumSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.enumSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3166,8 +3166,8 @@ private fun TestAllTypesProto3.MapStringForeignEnumEntry.protoMergeImpl(plus: Te
 
 private fun TestAllTypesProto3.MapStringForeignEnumEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value.value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.enumSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.enumSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -3217,7 +3217,7 @@ private fun ForeignMessage.protoMergeImpl(plus: ForeignMessage?): ForeignMessage
 
 private fun ForeignMessage.protoSizeImpl(): Int {
     var protoSize = 0
-    if (c != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(c)
+    if (c != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(c)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/conformance/lib/src/nativeMain/kotlin/pbandk/conformance/Platform.kt
+++ b/conformance/lib/src/nativeMain/kotlin/pbandk/conformance/Platform.kt
@@ -97,6 +97,6 @@ actual object Platform {
     }
 
     actual fun runBlockingMain(block: suspend CoroutineScope.() -> Unit) {
-        kotlinx.coroutines.runBlocking(block = block)
+        runBlocking(block = block)
     }
 }

--- a/conformance/lib/src/nativeMain/kotlin/pbandk/conformance/Platform.kt
+++ b/conformance/lib/src/nativeMain/kotlin/pbandk/conformance/Platform.kt
@@ -86,6 +86,8 @@ actual object Platform {
             if (bytesWritten.toInt() == -1) {
                 // errno
                 throw PosixException(posix_errno())
+            } else if (bytesWritten < arr.size) {
+                throw RuntimeException("Tried to write ${arr.size} bytes but only wrote $bytesWritten bytes")
             }
         }
     }

--- a/conformance/native/build.gradle.kts
+++ b/conformance/native/build.gradle.kts
@@ -1,32 +1,16 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     kotlin("multiplatform")
 }
 
-val executableBaseName = "conformance"
-val executableEntryPoint = "pbandk.conformance.main"
-
 kotlin {
-    linuxX64("linux") {
+    linuxX64("linux")
+    macosX64("macos")
+
+    targets.withType<KotlinNativeTarget> {
         binaries {
-            executable {
-                baseName = executableBaseName
-                entryPoint = executableEntryPoint
-
-                runTask?.args("")
-            }
-        }
-    }
-
-    macosX64("macos") {
-        binaries {
-            executable {
-                baseName = executableBaseName
-                entryPoint = executableEntryPoint
-
-                runTask?.args("")
-            }
+            executable("conformance")
         }
     }
 

--- a/conformance/native/src/commonMain/kotlin/Main.kt
+++ b/conformance/native/src/commonMain/kotlin/Main.kt
@@ -1,0 +1,1 @@
+fun main() = pbandk.conformance.main(emptyArray())

--- a/conformance/test-conformance.sh
+++ b/conformance/test-conformance.sh
@@ -18,8 +18,8 @@ if [ -z "$1" ] || [ "$1" = "js" ]; then
     $CONF_TEST_PATH --failure_list $DIR/js/failing_tests.txt $DIR/js/run.sh
 fi
 if [ -z "$1" ] || [ "$1" = "linux" ]; then
-    $CONF_TEST_PATH --failure_list $DIR/native/failing_tests.txt $DIR/native/build/bin/linux/debugExecutable/conformance.kexe
+    $CONF_TEST_PATH --failure_list $DIR/native/failing_tests.txt $DIR/native/build/bin/linux/conformanceReleaseExecutable/conformance.kexe
 fi
 if [ "$1" = "macos" ]; then
-    $CONF_TEST_PATH --failure_list $DIR/native/failing_tests.txt $DIR/native/build/bin/macos/debugExecutable/conformance.kexe
+    $CONF_TEST_PATH --failure_list $DIR/native/failing_tests.txt $DIR/native/build/bin/macos/conformanceReleaseExecutable/conformance.kexe
 fi

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.google.protobuf") version "0.8.12" apply false
 }
 
-val pbandkVersion by extra("0.8.2-SNAPSHOT")
+val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 subprojects {
     repositories {

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.google.protobuf") version "0.8.12" apply false
 }
 
-val pbandkVersion by extra("0.8.2-SNAPSHOT")
+val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 subprojects {
     repositories {

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 val kotlinxSerializationVersion by extra("0.20.0")
 val protobufVersion by extra("3.11.1")
-val pbandkVersion by extra("0.8.2-SNAPSHOT")
+val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 repositories {
     jcenter()

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/FileBuilder.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/FileBuilder.kt
@@ -1,6 +1,6 @@
 package pbandk.gen
 
-import pbandk.UtilImpl
+import pbandk.Util
 import pbandk.wkt.DescriptorProto
 import pbandk.wkt.EnumDescriptorProto
 import pbandk.wkt.FieldDescriptorProto
@@ -19,7 +19,7 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
         ctx.params["kotlin_package"]
             ?: ctx.fileDesc.options?.uninterpretedOption?.find {
                 it.name.singleOrNull()?.namePart == "kotlin_package"
-            }?.stringValue?.array?.let(UtilImpl::utf8ToString)
+            }?.stringValue?.array?.let(Util::utf8ToString)
             ?: ctx.packageMappings[ctx.fileDesc.`package`]
             ?: ctx.fileDesc.options?.javaPackage?.takeIf { it.isNotEmpty() }
             ?: ctx.fileDesc.`package`?.takeIf { it.isNotEmpty() }

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
@@ -140,10 +140,10 @@ private fun Version.protoMergeImpl(plus: Version?): Version = plus?.copy(
 
 private fun Version.protoSizeImpl(): Int {
     var protoSize = 0
-    if (major != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(major)
-    if (minor != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(minor)
-    if (patch != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.int32Size(patch)
-    if (suffix != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(suffix)
+    if (major != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(major)
+    if (minor != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(minor)
+    if (patch != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.int32Size(patch)
+    if (suffix != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(suffix)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -207,10 +207,10 @@ private fun CodeGeneratorRequest.protoMergeImpl(plus: CodeGeneratorRequest?): Co
 
 private fun CodeGeneratorRequest.protoSizeImpl(): Int {
     var protoSize = 0
-    if (fileToGenerate.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * fileToGenerate.size) + fileToGenerate.sumBy(pbandk.SizerImpl::stringSize)
-    if (parameter != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(parameter)
-    if (protoFile.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(15) * protoFile.size) + protoFile.sumBy(pbandk.SizerImpl::messageSize)
-    if (compilerVersion != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.messageSize(compilerVersion)
+    if (fileToGenerate.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * fileToGenerate.size) + fileToGenerate.sumBy(pbandk.Sizer::stringSize)
+    if (parameter != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(parameter)
+    if (protoFile.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(15) * protoFile.size) + protoFile.sumBy(pbandk.Sizer::messageSize)
+    if (compilerVersion != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.messageSize(compilerVersion)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -272,8 +272,8 @@ private fun CodeGeneratorResponse.protoMergeImpl(plus: CodeGeneratorResponse?): 
 
 private fun CodeGeneratorResponse.protoSizeImpl(): Int {
     var protoSize = 0
-    if (error != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(error)
-    if (file.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(15) * file.size) + file.sumBy(pbandk.SizerImpl::messageSize)
+    if (error != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(error)
+    if (file.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(15) * file.size) + file.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -326,9 +326,9 @@ private fun CodeGeneratorResponse.File.protoMergeImpl(plus: CodeGeneratorRespons
 
 private fun CodeGeneratorResponse.File.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (insertionPoint != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(insertionPoint)
-    if (content != null) protoSize += pbandk.SizerImpl.tagSize(15) + pbandk.SizerImpl.stringSize(content)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (insertionPoint != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(insertionPoint)
+    if (content != null) protoSize += pbandk.Sizer.tagSize(15) + pbandk.Sizer.stringSize(content)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -25,7 +27,19 @@ kotlin {
     // For Windows, should be changed to e.g. mingwX64
     macosX64()
     linuxX64()
-    
+
+    targets.withType<KotlinNativeTarget> {
+        val main by compilations.getting {
+            defaultSourceSet {
+                kotlin.srcDir("src/nativeMain/kotlin")
+            }
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
+            }
+        }
+    }
+
+
     sourceSets {
         all {
             languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
@@ -73,29 +87,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-js"))
             }
-        }
-
-        val nativeMain by creating {
-            dependsOn(commonMain)
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
-            }
-        }
-
-        val iosArm64Main by getting {
-            dependsOn(nativeMain)
-        }
-
-        val iosX64Main by getting {
-            dependsOn(nativeMain)
-        }
-
-        val macosX64Main by getting {
-            dependsOn(nativeMain)
-        }
-
-        val linuxX64Main by getting {
-            dependsOn(nativeMain)
         }
     }
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -27,6 +27,10 @@ kotlin {
     linuxX64()
     
     sourceSets {
+        all {
+            languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
+        }
+
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
@@ -72,6 +76,7 @@ kotlin {
         }
 
         val nativeMain by creating {
+            dependsOn(commonMain)
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
             }

--- a/runtime/src/commonMain/kotlin/pbandk/ByteArr.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ByteArr.kt
@@ -13,10 +13,10 @@ class ByteArr(val array: ByteArray) {
         val empty = ByteArr(ByteArray(0))
 
         override fun serialize(encoder: Encoder, obj: ByteArr) =
-            encoder.encodeString(UtilImpl.bytesToBase64(obj.array))
+            encoder.encodeString(Util.bytesToBase64(obj.array))
 
         @UseExperimental(ExperimentalStdlibApi::class)
         override fun deserialize(decoder: Decoder) =
-            ByteArr(UtilImpl.base64ToBytes(decoder.decodeString()))
+            ByteArr(Util.base64ToBytes(decoder.decodeString()))
     }
 }

--- a/runtime/src/commonMain/kotlin/pbandk/Sizer.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Sizer.kt
@@ -1,6 +1,6 @@
 package pbandk
 
-interface Sizer {
+expect object Sizer {
     fun tagSize(fieldNum: Int): Int
     fun doubleSize(value: Double): Int
     fun floatSize(value: Float): Int
@@ -26,5 +26,3 @@ interface Sizer {
         createEntry: (K, V, Map<Int, pbandk.UnknownField>) -> T
     ): Int
 }
-
-expect object SizerImpl : Sizer

--- a/runtime/src/commonMain/kotlin/pbandk/UnknownField.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/UnknownField.kt
@@ -10,23 +10,23 @@ data class UnknownField(val fieldNum: Int, val value: Value) {
     constructor(fieldNum: Int, value: ByteArray) :
         this(fieldNum, Value.LengthDelimited(ByteArr(value)))
     constructor(fieldNum: Int, value: String) :
-        this(fieldNum, Value.LengthDelimited(ByteArr(UtilImpl.stringToUtf8(value))))
+        this(fieldNum, Value.LengthDelimited(ByteArr(Util.stringToUtf8(value))))
 
     fun size() =
-        if (value is Value.Composite) (SizerImpl.tagSize(fieldNum) * value.values.size) + value.size()
-        else SizerImpl.tagSize(fieldNum) + value.size()
+        if (value is Value.Composite) (Sizer.tagSize(fieldNum) * value.values.size) + value.size()
+        else Sizer.tagSize(fieldNum) + value.size()
 
     sealed class Value {
         abstract fun size(): Int
 
         data class Varint(val varint: Long) : Value() {
-            override fun size() = SizerImpl.uInt64Size(varint)
+            override fun size() = Sizer.uInt64Size(varint)
         }
         data class Fixed64(val fixed64: Long) : Value() {
-            override fun size() = SizerImpl.fixed64Size(fixed64)
+            override fun size() = Sizer.fixed64Size(fixed64)
         }
         data class LengthDelimited(val bytes: ByteArr) : Value() {
-            override fun size() = SizerImpl.bytesSize(bytes)
+            override fun size() = Sizer.bytesSize(bytes)
         }
         object StartGroup : Value() {
             override fun size() = TODO()
@@ -35,7 +35,7 @@ data class UnknownField(val fieldNum: Int, val value: Value) {
             override fun size() = TODO()
         }
         data class Fixed32(val fixed32: Int) : Value() {
-            override fun size() = SizerImpl.fixed32Size(fixed32)
+            override fun size() = Sizer.fixed32Size(fixed32)
         }
         data class Composite(val values: List<Value>) : Value() {
             override fun size() = values.sumBy { it.size() }

--- a/runtime/src/commonMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Util.kt
@@ -2,7 +2,7 @@ package pbandk
 
 import pbandk.wkt.Timestamp
 
-interface Util {
+expect object Util {
     fun stringToUtf8(str: String): ByteArray
     fun utf8ToString(bytes: ByteArray): String
 
@@ -12,5 +12,3 @@ interface Util {
     fun timestampToString(ts: Timestamp.JsonMapper): String
     fun stringToTimestamp(str: String): Timestamp.JsonMapper
 }
-
-expect object UtilImpl : Util

--- a/runtime/src/commonMain/kotlin/pbandk/impl/AbstractUtil.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/impl/AbstractUtil.kt
@@ -32,21 +32,21 @@ package pbandk.impl
 import pbandk.Util
 import pbandk.wkt.Timestamp
 
-abstract class AbstractUtil : Util {
-    override fun base64ToBytes(str: String): ByteArray {
+abstract class AbstractUtil {
+    fun base64ToBytes(str: String): ByteArray {
         return str.decodeBase64ToArray()
             ?: throw RuntimeException("Unable to base64-decode string: $str")
     }
 
-    override fun bytesToBase64(bytes: ByteArray): String {
-        return utf8ToString(bytes.encodeBase64())
+    fun bytesToBase64(bytes: ByteArray): String {
+        return Util.utf8ToString(bytes.encodeBase64())
     }
 
-    override fun timestampToString(ts: Timestamp.JsonMapper): String {
+    fun timestampToString(ts: Timestamp.JsonMapper): String {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
-    override fun stringToTimestamp(str: String): Timestamp.JsonMapper {
+    fun stringToTimestamp(str: String): Timestamp.JsonMapper {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 

--- a/runtime/src/commonMain/kotlin/pbandk/impl/AbstractUtil.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/impl/AbstractUtil.kt
@@ -30,7 +30,6 @@
 package pbandk.impl
 
 import pbandk.Util
-import pbandk.wkt.Timestamp
 
 abstract class AbstractUtil {
     fun base64ToBytes(str: String): ByteArray {
@@ -40,14 +39,6 @@ abstract class AbstractUtil {
 
     fun bytesToBase64(bytes: ByteArray): String {
         return Util.utf8ToString(bytes.encodeBase64())
-    }
-
-    fun timestampToString(ts: Timestamp.JsonMapper): String {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    fun stringToTimestamp(str: String): Timestamp.JsonMapper {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
     private fun decodeSeq(bytes: ByteArray, pos: Int, len: Int): Int {

--- a/runtime/src/commonMain/kotlin/pbandk/impl/Marshaller.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/impl/Marshaller.kt
@@ -122,7 +122,7 @@ abstract class AbstractMarshaller : pbandk.Marshaller {
         writeUInt64(value)
     }
     override fun writeString(value: String) {
-        writeBytes(value = ByteArr(UtilImpl.stringToUtf8(value)))
+        writeBytes(value = ByteArr(Util.stringToUtf8(value)))
     }
     override fun writeFloat(value: Float) {
         writeFixed32(value.toRawBits())

--- a/runtime/src/commonMain/kotlin/pbandk/impl/Sizer.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/impl/Sizer.kt
@@ -2,22 +2,55 @@ package pbandk.impl
 
 import pbandk.*
 
+private class CodePointIterator(private val s: String) : Iterator<Int> {
+    var pos = 0
+
+    override fun hasNext(): Boolean = pos < s.length
+
+    override fun next(): Int {
+        if (pos >= s.length) throw NoSuchElementException()
+
+        val v = s[pos++]
+        if (v.isHighSurrogate() && pos < s.length) {
+            val l = s[pos]
+            if (l.isLowSurrogate()) {
+                pos++
+                return 0x10000 + (v - 0xD800).toInt() * 0x400 + (l - 0xDC00).toInt()
+            }
+        }
+        return v.toInt() and 0xffff
+    }
+}
+
+private class CodePointIterable(private val s: String) : Iterable<Int> {
+    override fun iterator(): Iterator<Int> = CodePointIterator(s)
+}
+
+fun utf8Len(value: String) = CodePointIterable(value).sumBy {
+    when (it) {
+        in 0..0x7f -> 1
+        in 0x80..0x7ff -> 2
+        in 0x800..0xffff -> 3
+        else -> 4
+    }
+}
+
 open class SizerImpl : Sizer {
     override fun stringSize(value: String): Int {
-        val len = UtilImpl.utf8Len(value)
+        val len = utf8Len(value)
         return uInt32Size(len) + len
     }
 
     override fun enumSize(value: Message.Enum) = int32Size(value.value)
     override fun messageSize(value: Message<*>) = uInt32Size(value.protoSize) + value.protoSize
     override fun <T> packedRepeatedSize(list: List<T>, sizeFn: (T) -> Int) =
-            if (list is ListWithSize && list.protoSize != null) list.protoSize + uInt32Size(list.protoSize)
-            else list.sumBy(sizeFn).let { it + uInt32Size(it) }
+        if (list is ListWithSize && list.protoSize != null) list.protoSize + uInt32Size(list.protoSize)
+        else list.sumBy(sizeFn).let { it + uInt32Size(it) }
 
     override fun <K, V, T : Message<T>> mapSize(
-            fieldNumber: Int,
-            map: Map<K, V>,
-            createEntry: (K, V, Map<Int, pbandk.UnknownField>) -> T
+        fieldNumber: Int,
+        map: Map<K, V>,
+        createEntry: (K, V, Map<Int, pbandk.UnknownField>) -> T
     ) = tagSize(fieldNumber).let { tagSize ->
         map.entries.sumBy { e ->
             val msg = e as? Message<*> ?: createEntry(e.key, e.value, emptyMap())

--- a/runtime/src/commonMain/kotlin/pbandk/impl/Unmarshaller.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/impl/Unmarshaller.kt
@@ -130,7 +130,7 @@ open class Unmarshaller(val stream: ByteArrayUnmarshallerInputStream,
         return lastTag
     }
 
-    override fun readString() = UtilImpl.utf8ToString(readBytes().array)
+    override fun readString() = Util.utf8ToString(readBytes().array)
     override fun readBytes() = ByteArr(readRawBytes(readRawVarint32()))
 
     override fun <T : Message.Enum> readEnum(s: Message.Enum.Companion<T>) = s.fromValue(readEnum())

--- a/runtime/src/commonMain/kotlin/pbandk/ser/TimestampSerializer.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ser/TimestampSerializer.kt
@@ -1,7 +1,7 @@
 package pbandk.ser
 
 import kotlinx.serialization.*
-import pbandk.UtilImpl
+import pbandk.Util
 import pbandk.wkt.Timestamp
 
 @Serializer(forClass = Timestamp.JsonMapper::class)
@@ -11,9 +11,9 @@ object TimestampSerializer: KSerializer<Timestamp.JsonMapper> {
         PrimitiveDescriptor("Timestamp.JsonMapper", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, obj: Timestamp.JsonMapper) =
-        encoder.encodeString(UtilImpl.timestampToString(obj))
+        encoder.encodeString(Util.timestampToString(obj))
 
     override fun deserialize(decoder: Decoder) =
-        UtilImpl.stringToTimestamp(decoder.decodeString())
+        Util.stringToTimestamp(decoder.decodeString())
 
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
@@ -40,8 +40,8 @@ private fun Any.protoMergeImpl(plus: Any?): Any = plus?.copy(
 
 private fun Any.protoSizeImpl(): Int {
     var protoSize = 0
-    if (typeUrl.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(typeUrl)
-    if (value.array.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.bytesSize(value)
+    if (typeUrl.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(typeUrl)
+    if (value.array.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.bytesSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
@@ -128,13 +128,13 @@ private fun Api.protoMergeImpl(plus: Api?): Api = plus?.copy(
 
 private fun Api.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (methods.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * methods.size) + methods.sumBy(pbandk.SizerImpl::messageSize)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
-    if (version.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(version)
-    if (sourceContext != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.messageSize(sourceContext)
-    if (mixins.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(6) * mixins.size) + mixins.sumBy(pbandk.SizerImpl::messageSize)
-    if (syntax.value != 0) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.enumSize(syntax)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (methods.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * methods.size) + methods.sumBy(pbandk.Sizer::messageSize)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
+    if (version.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(version)
+    if (sourceContext != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.messageSize(sourceContext)
+    if (mixins.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(6) * mixins.size) + mixins.sumBy(pbandk.Sizer::messageSize)
+    if (syntax.value != 0) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.enumSize(syntax)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -211,13 +211,13 @@ private fun Method.protoMergeImpl(plus: Method?): Method = plus?.copy(
 
 private fun Method.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (requestTypeUrl.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(requestTypeUrl)
-    if (requestStreaming) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.boolSize(requestStreaming)
-    if (responseTypeUrl.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(responseTypeUrl)
-    if (responseStreaming) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.boolSize(responseStreaming)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(6) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
-    if (syntax.value != 0) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.enumSize(syntax)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (requestTypeUrl.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(requestTypeUrl)
+    if (requestStreaming) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.boolSize(requestStreaming)
+    if (responseTypeUrl.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(responseTypeUrl)
+    if (responseStreaming) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.boolSize(responseStreaming)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(6) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
+    if (syntax.value != 0) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.enumSize(syntax)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -293,8 +293,8 @@ private fun Mixin.protoMergeImpl(plus: Mixin?): Mixin = plus?.copy(
 
 private fun Mixin.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (root.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(root)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (root.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(root)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -1070,7 +1070,7 @@ private fun FileDescriptorSet.protoMergeImpl(plus: FileDescriptorSet?): FileDesc
 
 private fun FileDescriptorSet.protoSizeImpl(): Int {
     var protoSize = 0
-    if (file.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * file.size) + file.sumBy(pbandk.SizerImpl::messageSize)
+    if (file.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * file.size) + file.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1127,18 +1127,18 @@ private fun FileDescriptorProto.protoMergeImpl(plus: FileDescriptorProto?): File
 
 private fun FileDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (`package` != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(`package`)
-    if (dependency.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * dependency.size) + dependency.sumBy(pbandk.SizerImpl::stringSize)
-    if (publicDependency.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(10) * publicDependency.size) + publicDependency.sumBy(pbandk.SizerImpl::int32Size)
-    if (weakDependency.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(11) * weakDependency.size) + weakDependency.sumBy(pbandk.SizerImpl::int32Size)
-    if (messageType.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(4) * messageType.size) + messageType.sumBy(pbandk.SizerImpl::messageSize)
-    if (enumType.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(5) * enumType.size) + enumType.sumBy(pbandk.SizerImpl::messageSize)
-    if (service.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(6) * service.size) + service.sumBy(pbandk.SizerImpl::messageSize)
-    if (extension.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(7) * extension.size) + extension.sumBy(pbandk.SizerImpl::messageSize)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.messageSize(options)
-    if (sourceCodeInfo != null) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.messageSize(sourceCodeInfo)
-    if (syntax != null) protoSize += pbandk.SizerImpl.tagSize(12) + pbandk.SizerImpl.stringSize(syntax)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (`package` != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(`package`)
+    if (dependency.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * dependency.size) + dependency.sumBy(pbandk.Sizer::stringSize)
+    if (publicDependency.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(10) * publicDependency.size) + publicDependency.sumBy(pbandk.Sizer::int32Size)
+    if (weakDependency.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(11) * weakDependency.size) + weakDependency.sumBy(pbandk.Sizer::int32Size)
+    if (messageType.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(4) * messageType.size) + messageType.sumBy(pbandk.Sizer::messageSize)
+    if (enumType.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(5) * enumType.size) + enumType.sumBy(pbandk.Sizer::messageSize)
+    if (service.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(6) * service.size) + service.sumBy(pbandk.Sizer::messageSize)
+    if (extension.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(7) * extension.size) + extension.sumBy(pbandk.Sizer::messageSize)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.messageSize(options)
+    if (sourceCodeInfo != null) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.messageSize(sourceCodeInfo)
+    if (syntax != null) protoSize += pbandk.Sizer.tagSize(12) + pbandk.Sizer.stringSize(syntax)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1250,16 +1250,16 @@ private fun DescriptorProto.protoMergeImpl(plus: DescriptorProto?): DescriptorPr
 
 private fun DescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (field.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * field.size) + field.sumBy(pbandk.SizerImpl::messageSize)
-    if (extension.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(6) * extension.size) + extension.sumBy(pbandk.SizerImpl::messageSize)
-    if (nestedType.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * nestedType.size) + nestedType.sumBy(pbandk.SizerImpl::messageSize)
-    if (enumType.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(4) * enumType.size) + enumType.sumBy(pbandk.SizerImpl::messageSize)
-    if (extensionRange.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(5) * extensionRange.size) + extensionRange.sumBy(pbandk.SizerImpl::messageSize)
-    if (oneofDecl.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(8) * oneofDecl.size) + oneofDecl.sumBy(pbandk.SizerImpl::messageSize)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.messageSize(options)
-    if (reservedRange.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(9) * reservedRange.size) + reservedRange.sumBy(pbandk.SizerImpl::messageSize)
-    if (reservedName.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(10) * reservedName.size) + reservedName.sumBy(pbandk.SizerImpl::stringSize)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (field.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * field.size) + field.sumBy(pbandk.Sizer::messageSize)
+    if (extension.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(6) * extension.size) + extension.sumBy(pbandk.Sizer::messageSize)
+    if (nestedType.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * nestedType.size) + nestedType.sumBy(pbandk.Sizer::messageSize)
+    if (enumType.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(4) * enumType.size) + enumType.sumBy(pbandk.Sizer::messageSize)
+    if (extensionRange.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(5) * extensionRange.size) + extensionRange.sumBy(pbandk.Sizer::messageSize)
+    if (oneofDecl.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(8) * oneofDecl.size) + oneofDecl.sumBy(pbandk.Sizer::messageSize)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.messageSize(options)
+    if (reservedRange.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(9) * reservedRange.size) + reservedRange.sumBy(pbandk.Sizer::messageSize)
+    if (reservedName.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(10) * reservedName.size) + reservedName.sumBy(pbandk.Sizer::stringSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1354,9 +1354,9 @@ private fun DescriptorProto.ExtensionRange.protoMergeImpl(plus: DescriptorProto.
 
 private fun DescriptorProto.ExtensionRange.protoSizeImpl(): Int {
     var protoSize = 0
-    if (start != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(start)
-    if (end != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(end)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.messageSize(options)
+    if (start != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(start)
+    if (end != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(end)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.messageSize(options)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1413,8 +1413,8 @@ private fun DescriptorProto.ReservedRange.protoMergeImpl(plus: DescriptorProto.R
 
 private fun DescriptorProto.ReservedRange.protoSizeImpl(): Int {
     var protoSize = 0
-    if (start != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(start)
-    if (end != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(end)
+    if (start != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(start)
+    if (end != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(end)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1465,7 +1465,7 @@ private fun ExtensionRangeOptions.protoMergeImpl(plus: ExtensionRangeOptions?): 
 
 private fun ExtensionRangeOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1520,16 +1520,16 @@ private fun FieldDescriptorProto.protoMergeImpl(plus: FieldDescriptorProto?): Fi
 
 private fun FieldDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (number != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.int32Size(number)
-    if (label != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.enumSize(label)
-    if (type != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.enumSize(type)
-    if (typeName != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.stringSize(typeName)
-    if (extendee != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(extendee)
-    if (defaultValue != null) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.stringSize(defaultValue)
-    if (oneofIndex != null) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.int32Size(oneofIndex)
-    if (jsonName != null) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.stringSize(jsonName)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.messageSize(options)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (number != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.int32Size(number)
+    if (label != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.enumSize(label)
+    if (type != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.enumSize(type)
+    if (typeName != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.stringSize(typeName)
+    if (extendee != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(extendee)
+    if (defaultValue != null) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.stringSize(defaultValue)
+    if (oneofIndex != null) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.int32Size(oneofIndex)
+    if (jsonName != null) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.stringSize(jsonName)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.messageSize(options)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1623,8 +1623,8 @@ private fun OneofDescriptorProto.protoMergeImpl(plus: OneofDescriptorProto?): On
 
 private fun OneofDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(options)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(options)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1679,11 +1679,11 @@ private fun EnumDescriptorProto.protoMergeImpl(plus: EnumDescriptorProto?): Enum
 
 private fun EnumDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (value.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * value.size) + value.sumBy(pbandk.SizerImpl::messageSize)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.messageSize(options)
-    if (reservedRange.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(4) * reservedRange.size) + reservedRange.sumBy(pbandk.SizerImpl::messageSize)
-    if (reservedName.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(5) * reservedName.size) + reservedName.sumBy(pbandk.SizerImpl::stringSize)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (value.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * value.size) + value.sumBy(pbandk.Sizer::messageSize)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.messageSize(options)
+    if (reservedRange.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(4) * reservedRange.size) + reservedRange.sumBy(pbandk.Sizer::messageSize)
+    if (reservedName.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(5) * reservedName.size) + reservedName.sumBy(pbandk.Sizer::stringSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1751,8 +1751,8 @@ private fun EnumDescriptorProto.EnumReservedRange.protoMergeImpl(plus: EnumDescr
 
 private fun EnumDescriptorProto.EnumReservedRange.protoSizeImpl(): Int {
     var protoSize = 0
-    if (start != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(start)
-    if (end != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(end)
+    if (start != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(start)
+    if (end != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(end)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1805,9 +1805,9 @@ private fun EnumValueDescriptorProto.protoMergeImpl(plus: EnumValueDescriptorPro
 
 private fun EnumValueDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (number != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(number)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.messageSize(options)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (number != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(number)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.messageSize(options)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1865,9 +1865,9 @@ private fun ServiceDescriptorProto.protoMergeImpl(plus: ServiceDescriptorProto?)
 
 private fun ServiceDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (method.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * method.size) + method.sumBy(pbandk.SizerImpl::messageSize)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.messageSize(options)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (method.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * method.size) + method.sumBy(pbandk.Sizer::messageSize)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.messageSize(options)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -1928,12 +1928,12 @@ private fun MethodDescriptorProto.protoMergeImpl(plus: MethodDescriptorProto?): 
 
 private fun MethodDescriptorProto.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (inputType != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(inputType)
-    if (outputType != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.stringSize(outputType)
-    if (options != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.messageSize(options)
-    if (clientStreaming != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.boolSize(clientStreaming)
-    if (serverStreaming != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.boolSize(serverStreaming)
+    if (name != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (inputType != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(inputType)
+    if (outputType != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.stringSize(outputType)
+    if (options != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.messageSize(options)
+    if (clientStreaming != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.boolSize(clientStreaming)
+    if (serverStreaming != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.boolSize(serverStreaming)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2025,27 +2025,27 @@ private fun FileOptions.protoMergeImpl(plus: FileOptions?): FileOptions = plus?.
 
 private fun FileOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (javaPackage != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(javaPackage)
-    if (javaOuterClassname != null) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.stringSize(javaOuterClassname)
-    if (javaMultipleFiles != null) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.boolSize(javaMultipleFiles)
-    if (javaGenerateEqualsAndHash != null) protoSize += pbandk.SizerImpl.tagSize(20) + pbandk.SizerImpl.boolSize(javaGenerateEqualsAndHash)
-    if (javaStringCheckUtf8 != null) protoSize += pbandk.SizerImpl.tagSize(27) + pbandk.SizerImpl.boolSize(javaStringCheckUtf8)
-    if (optimizeFor != null) protoSize += pbandk.SizerImpl.tagSize(9) + pbandk.SizerImpl.enumSize(optimizeFor)
-    if (goPackage != null) protoSize += pbandk.SizerImpl.tagSize(11) + pbandk.SizerImpl.stringSize(goPackage)
-    if (ccGenericServices != null) protoSize += pbandk.SizerImpl.tagSize(16) + pbandk.SizerImpl.boolSize(ccGenericServices)
-    if (javaGenericServices != null) protoSize += pbandk.SizerImpl.tagSize(17) + pbandk.SizerImpl.boolSize(javaGenericServices)
-    if (pyGenericServices != null) protoSize += pbandk.SizerImpl.tagSize(18) + pbandk.SizerImpl.boolSize(pyGenericServices)
-    if (phpGenericServices != null) protoSize += pbandk.SizerImpl.tagSize(42) + pbandk.SizerImpl.boolSize(phpGenericServices)
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(23) + pbandk.SizerImpl.boolSize(deprecated)
-    if (ccEnableArenas != null) protoSize += pbandk.SizerImpl.tagSize(31) + pbandk.SizerImpl.boolSize(ccEnableArenas)
-    if (objcClassPrefix != null) protoSize += pbandk.SizerImpl.tagSize(36) + pbandk.SizerImpl.stringSize(objcClassPrefix)
-    if (csharpNamespace != null) protoSize += pbandk.SizerImpl.tagSize(37) + pbandk.SizerImpl.stringSize(csharpNamespace)
-    if (swiftPrefix != null) protoSize += pbandk.SizerImpl.tagSize(39) + pbandk.SizerImpl.stringSize(swiftPrefix)
-    if (phpClassPrefix != null) protoSize += pbandk.SizerImpl.tagSize(40) + pbandk.SizerImpl.stringSize(phpClassPrefix)
-    if (phpNamespace != null) protoSize += pbandk.SizerImpl.tagSize(41) + pbandk.SizerImpl.stringSize(phpNamespace)
-    if (phpMetadataNamespace != null) protoSize += pbandk.SizerImpl.tagSize(44) + pbandk.SizerImpl.stringSize(phpMetadataNamespace)
-    if (rubyPackage != null) protoSize += pbandk.SizerImpl.tagSize(45) + pbandk.SizerImpl.stringSize(rubyPackage)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (javaPackage != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(javaPackage)
+    if (javaOuterClassname != null) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.stringSize(javaOuterClassname)
+    if (javaMultipleFiles != null) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.boolSize(javaMultipleFiles)
+    if (javaGenerateEqualsAndHash != null) protoSize += pbandk.Sizer.tagSize(20) + pbandk.Sizer.boolSize(javaGenerateEqualsAndHash)
+    if (javaStringCheckUtf8 != null) protoSize += pbandk.Sizer.tagSize(27) + pbandk.Sizer.boolSize(javaStringCheckUtf8)
+    if (optimizeFor != null) protoSize += pbandk.Sizer.tagSize(9) + pbandk.Sizer.enumSize(optimizeFor)
+    if (goPackage != null) protoSize += pbandk.Sizer.tagSize(11) + pbandk.Sizer.stringSize(goPackage)
+    if (ccGenericServices != null) protoSize += pbandk.Sizer.tagSize(16) + pbandk.Sizer.boolSize(ccGenericServices)
+    if (javaGenericServices != null) protoSize += pbandk.Sizer.tagSize(17) + pbandk.Sizer.boolSize(javaGenericServices)
+    if (pyGenericServices != null) protoSize += pbandk.Sizer.tagSize(18) + pbandk.Sizer.boolSize(pyGenericServices)
+    if (phpGenericServices != null) protoSize += pbandk.Sizer.tagSize(42) + pbandk.Sizer.boolSize(phpGenericServices)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(23) + pbandk.Sizer.boolSize(deprecated)
+    if (ccEnableArenas != null) protoSize += pbandk.Sizer.tagSize(31) + pbandk.Sizer.boolSize(ccEnableArenas)
+    if (objcClassPrefix != null) protoSize += pbandk.Sizer.tagSize(36) + pbandk.Sizer.stringSize(objcClassPrefix)
+    if (csharpNamespace != null) protoSize += pbandk.Sizer.tagSize(37) + pbandk.Sizer.stringSize(csharpNamespace)
+    if (swiftPrefix != null) protoSize += pbandk.Sizer.tagSize(39) + pbandk.Sizer.stringSize(swiftPrefix)
+    if (phpClassPrefix != null) protoSize += pbandk.Sizer.tagSize(40) + pbandk.Sizer.stringSize(phpClassPrefix)
+    if (phpNamespace != null) protoSize += pbandk.Sizer.tagSize(41) + pbandk.Sizer.stringSize(phpNamespace)
+    if (phpMetadataNamespace != null) protoSize += pbandk.Sizer.tagSize(44) + pbandk.Sizer.stringSize(phpMetadataNamespace)
+    if (rubyPackage != null) protoSize += pbandk.Sizer.tagSize(45) + pbandk.Sizer.stringSize(rubyPackage)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2200,11 +2200,11 @@ private fun MessageOptions.protoMergeImpl(plus: MessageOptions?): MessageOptions
 
 private fun MessageOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (messageSetWireFormat != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(messageSetWireFormat)
-    if (noStandardDescriptorAccessor != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(noStandardDescriptorAccessor)
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.boolSize(deprecated)
-    if (mapEntry != null) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.boolSize(mapEntry)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (messageSetWireFormat != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(messageSetWireFormat)
+    if (noStandardDescriptorAccessor != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(noStandardDescriptorAccessor)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.boolSize(deprecated)
+    if (mapEntry != null) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.boolSize(mapEntry)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2277,13 +2277,13 @@ private fun FieldOptions.protoMergeImpl(plus: FieldOptions?): FieldOptions = plu
 
 private fun FieldOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (ctype != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.enumSize(ctype)
-    if (packed != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(packed)
-    if (jstype != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.enumSize(jstype)
-    if (lazy != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.boolSize(lazy)
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.boolSize(deprecated)
-    if (weak != null) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.boolSize(weak)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (ctype != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.enumSize(ctype)
+    if (packed != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(packed)
+    if (jstype != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.enumSize(jstype)
+    if (lazy != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.boolSize(lazy)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.boolSize(deprecated)
+    if (weak != null) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.boolSize(weak)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2360,7 +2360,7 @@ private fun OneofOptions.protoMergeImpl(plus: OneofOptions?): OneofOptions = plu
 
 private fun OneofOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2408,9 +2408,9 @@ private fun EnumOptions.protoMergeImpl(plus: EnumOptions?): EnumOptions = plus?.
 
 private fun EnumOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (allowAlias != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(allowAlias)
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.boolSize(deprecated)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (allowAlias != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(allowAlias)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.boolSize(deprecated)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2467,8 +2467,8 @@ private fun EnumValueOptions.protoMergeImpl(plus: EnumValueOptions?): EnumValueO
 
 private fun EnumValueOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(deprecated)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(deprecated)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2520,8 +2520,8 @@ private fun ServiceOptions.protoMergeImpl(plus: ServiceOptions?): ServiceOptions
 
 private fun ServiceOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(33) + pbandk.SizerImpl.boolSize(deprecated)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(33) + pbandk.Sizer.boolSize(deprecated)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2574,9 +2574,9 @@ private fun MethodOptions.protoMergeImpl(plus: MethodOptions?): MethodOptions = 
 
 private fun MethodOptions.protoSizeImpl(): Int {
     var protoSize = 0
-    if (deprecated != null) protoSize += pbandk.SizerImpl.tagSize(33) + pbandk.SizerImpl.boolSize(deprecated)
-    if (idempotencyLevel != null) protoSize += pbandk.SizerImpl.tagSize(34) + pbandk.SizerImpl.enumSize(idempotencyLevel)
-    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.SizerImpl::messageSize)
+    if (deprecated != null) protoSize += pbandk.Sizer.tagSize(33) + pbandk.Sizer.boolSize(deprecated)
+    if (idempotencyLevel != null) protoSize += pbandk.Sizer.tagSize(34) + pbandk.Sizer.enumSize(idempotencyLevel)
+    if (uninterpretedOption.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(999) * uninterpretedOption.size) + uninterpretedOption.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2638,13 +2638,13 @@ private fun UninterpretedOption.protoMergeImpl(plus: UninterpretedOption?): Unin
 
 private fun UninterpretedOption.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * name.size) + name.sumBy(pbandk.SizerImpl::messageSize)
-    if (identifierValue != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.stringSize(identifierValue)
-    if (positiveIntValue != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.uInt64Size(positiveIntValue)
-    if (negativeIntValue != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.int64Size(negativeIntValue)
-    if (doubleValue != null) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.doubleSize(doubleValue)
-    if (stringValue != null) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.bytesSize(stringValue)
-    if (aggregateValue != null) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.stringSize(aggregateValue)
+    if (name.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * name.size) + name.sumBy(pbandk.Sizer::messageSize)
+    if (identifierValue != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.stringSize(identifierValue)
+    if (positiveIntValue != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.uInt64Size(positiveIntValue)
+    if (negativeIntValue != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.int64Size(negativeIntValue)
+    if (doubleValue != null) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.doubleSize(doubleValue)
+    if (stringValue != null) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.bytesSize(stringValue)
+    if (aggregateValue != null) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.stringSize(aggregateValue)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2720,8 +2720,8 @@ private fun UninterpretedOption.NamePart.protoMergeImpl(plus: UninterpretedOptio
 
 private fun UninterpretedOption.NamePart.protoSizeImpl(): Int {
     var protoSize = 0
-    if (namePart.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(namePart)
-    if (isExtension) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.boolSize(isExtension)
+    if (namePart.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(namePart)
+    if (isExtension) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.boolSize(isExtension)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2772,7 +2772,7 @@ private fun SourceCodeInfo.protoMergeImpl(plus: SourceCodeInfo?): SourceCodeInfo
 
 private fun SourceCodeInfo.protoSizeImpl(): Int {
     var protoSize = 0
-    if (location.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * location.size) + location.sumBy(pbandk.SizerImpl::messageSize)
+    if (location.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * location.size) + location.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2822,18 +2822,18 @@ private fun SourceCodeInfo.Location.protoMergeImpl(plus: SourceCodeInfo.Location
 
 private fun SourceCodeInfo.Location.protoSizeImpl(): Int {
     var protoSize = 0
-    if (path.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.packedRepeatedSize(path, pbandk.SizerImpl::int32Size)
-    if (span.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.packedRepeatedSize(span, pbandk.SizerImpl::int32Size)
-    if (leadingComments != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.stringSize(leadingComments)
-    if (trailingComments != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(trailingComments)
-    if (leadingDetachedComments.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(6) * leadingDetachedComments.size) + leadingDetachedComments.sumBy(pbandk.SizerImpl::stringSize)
+    if (path.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.packedRepeatedSize(path, pbandk.Sizer::int32Size)
+    if (span.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.packedRepeatedSize(span, pbandk.Sizer::int32Size)
+    if (leadingComments != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.stringSize(leadingComments)
+    if (trailingComments != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(trailingComments)
+    if (leadingDetachedComments.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(6) * leadingDetachedComments.size) + leadingDetachedComments.sumBy(pbandk.Sizer::stringSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
 
 private fun SourceCodeInfo.Location.protoMarshalImpl(protoMarshal: pbandk.Marshaller) {
-    if (path.isNotEmpty()) protoMarshal.writeTag(10).writePackedRepeated(path, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
-    if (span.isNotEmpty()) protoMarshal.writeTag(18).writePackedRepeated(span, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
+    if (path.isNotEmpty()) protoMarshal.writeTag(10).writePackedRepeated(path, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
+    if (span.isNotEmpty()) protoMarshal.writeTag(18).writePackedRepeated(span, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
     if (leadingComments != null) protoMarshal.writeTag(26).writeString(leadingComments)
     if (trailingComments != null) protoMarshal.writeTag(34).writeString(trailingComments)
     if (leadingDetachedComments.isNotEmpty()) leadingDetachedComments.forEach { protoMarshal.writeTag(50).writeString(it) }
@@ -2893,7 +2893,7 @@ private fun GeneratedCodeInfo.protoMergeImpl(plus: GeneratedCodeInfo?): Generate
 
 private fun GeneratedCodeInfo.protoSizeImpl(): Int {
     var protoSize = 0
-    if (annotation.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * annotation.size) + annotation.sumBy(pbandk.SizerImpl::messageSize)
+    if (annotation.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * annotation.size) + annotation.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -2942,16 +2942,16 @@ private fun GeneratedCodeInfo.Annotation.protoMergeImpl(plus: GeneratedCodeInfo.
 
 private fun GeneratedCodeInfo.Annotation.protoSizeImpl(): Int {
     var protoSize = 0
-    if (path.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.packedRepeatedSize(path, pbandk.SizerImpl::int32Size)
-    if (sourceFile != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(sourceFile)
-    if (begin != null) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.int32Size(begin)
-    if (end != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.int32Size(end)
+    if (path.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.packedRepeatedSize(path, pbandk.Sizer::int32Size)
+    if (sourceFile != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(sourceFile)
+    if (begin != null) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.int32Size(begin)
+    if (end != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.int32Size(end)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
 
 private fun GeneratedCodeInfo.Annotation.protoMarshalImpl(protoMarshal: pbandk.Marshaller) {
-    if (path.isNotEmpty()) protoMarshal.writeTag(10).writePackedRepeated(path, pbandk.SizerImpl::int32Size, protoMarshal::writeInt32)
+    if (path.isNotEmpty()) protoMarshal.writeTag(10).writePackedRepeated(path, pbandk.Sizer::int32Size, protoMarshal::writeInt32)
     if (sourceFile != null) protoMarshal.writeTag(18).writeString(sourceFile)
     if (begin != null) protoMarshal.writeTag(24).writeInt32(begin)
     if (end != null) protoMarshal.writeTag(32).writeInt32(end)

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
@@ -40,8 +40,8 @@ private fun Duration.protoMergeImpl(plus: Duration?): Duration = plus?.copy(
 
 private fun Duration.protoSizeImpl(): Int {
     var protoSize = 0
-    if (seconds != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int64Size(seconds)
-    if (nanos != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(nanos)
+    if (seconds != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int64Size(seconds)
+    if (nanos != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(nanos)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
@@ -38,7 +38,7 @@ private fun FieldMask.protoMergeImpl(plus: FieldMask?): FieldMask = plus?.copy(
 
 private fun FieldMask.protoSizeImpl(): Int {
     var protoSize = 0
-    if (paths.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * paths.size) + paths.sumBy(pbandk.SizerImpl::stringSize)
+    if (paths.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * paths.size) + paths.sumBy(pbandk.Sizer::stringSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
@@ -37,7 +37,7 @@ private fun SourceContext.protoMergeImpl(plus: SourceContext?): SourceContext = 
 
 private fun SourceContext.protoSizeImpl(): Int {
     var protoSize = 0
-    if (fileName.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(fileName)
+    if (fileName.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(fileName)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
@@ -160,7 +160,7 @@ private fun Struct.protoMergeImpl(plus: Struct?): Struct = plus?.copy(
 
 private fun Struct.protoSizeImpl(): Int {
     var protoSize = 0
-    if (fields.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(1, fields, pbandk.wkt.Struct::FieldsEntry)
+    if (fields.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(1, fields, pbandk.wkt.Struct::FieldsEntry)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -206,8 +206,8 @@ private fun Struct.FieldsEntry.protoMergeImpl(plus: Struct.FieldsEntry?): Struct
 
 private fun Struct.FieldsEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -266,12 +266,12 @@ private fun Value.protoMergeImpl(plus: Value?): Value = plus?.copy(
 private fun Value.protoSizeImpl(): Int {
     var protoSize = 0
     when (kind) {
-        is Value.Kind.NullValue -> protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.enumSize(kind.value)
-        is Value.Kind.NumberValue -> protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.doubleSize(kind.value)
-        is Value.Kind.StringValue -> protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.stringSize(kind.value)
-        is Value.Kind.BoolValue -> protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.boolSize(kind.value)
-        is Value.Kind.StructValue -> protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.messageSize(kind.value)
-        is Value.Kind.ListValue -> protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.messageSize(kind.value)
+        is Value.Kind.NullValue -> protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.enumSize(kind.value)
+        is Value.Kind.NumberValue -> protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.doubleSize(kind.value)
+        is Value.Kind.StringValue -> protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.stringSize(kind.value)
+        is Value.Kind.BoolValue -> protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.boolSize(kind.value)
+        is Value.Kind.StructValue -> protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.messageSize(kind.value)
+        is Value.Kind.ListValue -> protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.messageSize(kind.value)
     }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
@@ -339,7 +339,7 @@ private fun ListValue.protoMergeImpl(plus: ListValue?): ListValue = plus?.copy(
 
 private fun ListValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (values.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * values.size) + values.sumBy(pbandk.SizerImpl::messageSize)
+    if (values.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * values.size) + values.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
@@ -40,8 +40,8 @@ private fun Timestamp.protoMergeImpl(plus: Timestamp?): Timestamp = plus?.copy(
 
 private fun Timestamp.protoSizeImpl(): Int {
     var protoSize = 0
-    if (seconds != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int64Size(seconds)
-    if (nanos != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(nanos)
+    if (seconds != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int64Size(seconds)
+    if (nanos != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(nanos)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
@@ -267,12 +267,12 @@ private fun Type.protoMergeImpl(plus: Type?): Type = plus?.copy(
 
 private fun Type.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (fields.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * fields.size) + fields.sumBy(pbandk.SizerImpl::messageSize)
-    if (oneofs.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * oneofs.size) + oneofs.sumBy(pbandk.SizerImpl::stringSize)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(4) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
-    if (sourceContext != null) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.messageSize(sourceContext)
-    if (syntax.value != 0) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.enumSize(syntax)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (fields.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * fields.size) + fields.sumBy(pbandk.Sizer::messageSize)
+    if (oneofs.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * oneofs.size) + oneofs.sumBy(pbandk.Sizer::stringSize)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(4) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
+    if (sourceContext != null) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.messageSize(sourceContext)
+    if (syntax.value != 0) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.enumSize(syntax)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -344,16 +344,16 @@ private fun Field.protoMergeImpl(plus: Field?): Field = plus?.copy(
 
 private fun Field.protoSizeImpl(): Int {
     var protoSize = 0
-    if (kind.value != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.enumSize(kind)
-    if (cardinality.value != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.enumSize(cardinality)
-    if (number != 0) protoSize += pbandk.SizerImpl.tagSize(3) + pbandk.SizerImpl.int32Size(number)
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.stringSize(name)
-    if (typeUrl.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(6) + pbandk.SizerImpl.stringSize(typeUrl)
-    if (oneofIndex != 0) protoSize += pbandk.SizerImpl.tagSize(7) + pbandk.SizerImpl.int32Size(oneofIndex)
-    if (packed) protoSize += pbandk.SizerImpl.tagSize(8) + pbandk.SizerImpl.boolSize(packed)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(9) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
-    if (jsonName.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(10) + pbandk.SizerImpl.stringSize(jsonName)
-    if (defaultValue.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(11) + pbandk.SizerImpl.stringSize(defaultValue)
+    if (kind.value != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.enumSize(kind)
+    if (cardinality.value != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.enumSize(cardinality)
+    if (number != 0) protoSize += pbandk.Sizer.tagSize(3) + pbandk.Sizer.int32Size(number)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.stringSize(name)
+    if (typeUrl.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(6) + pbandk.Sizer.stringSize(typeUrl)
+    if (oneofIndex != 0) protoSize += pbandk.Sizer.tagSize(7) + pbandk.Sizer.int32Size(oneofIndex)
+    if (packed) protoSize += pbandk.Sizer.tagSize(8) + pbandk.Sizer.boolSize(packed)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(9) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
+    if (jsonName.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(10) + pbandk.Sizer.stringSize(jsonName)
+    if (defaultValue.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(11) + pbandk.Sizer.stringSize(defaultValue)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -448,11 +448,11 @@ private fun Enum.protoMergeImpl(plus: Enum?): Enum = plus?.copy(
 
 private fun Enum.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (enumvalue.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * enumvalue.size) + enumvalue.sumBy(pbandk.SizerImpl::messageSize)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
-    if (sourceContext != null) protoSize += pbandk.SizerImpl.tagSize(4) + pbandk.SizerImpl.messageSize(sourceContext)
-    if (syntax.value != 0) protoSize += pbandk.SizerImpl.tagSize(5) + pbandk.SizerImpl.enumSize(syntax)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (enumvalue.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * enumvalue.size) + enumvalue.sumBy(pbandk.Sizer::messageSize)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
+    if (sourceContext != null) protoSize += pbandk.Sizer.tagSize(4) + pbandk.Sizer.messageSize(sourceContext)
+    if (syntax.value != 0) protoSize += pbandk.Sizer.tagSize(5) + pbandk.Sizer.enumSize(syntax)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -519,9 +519,9 @@ private fun EnumValue.protoMergeImpl(plus: EnumValue?): EnumValue = plus?.copy(
 
 private fun EnumValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (number != 0) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.int32Size(number)
-    if (options.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(3) * options.size) + options.sumBy(pbandk.SizerImpl::messageSize)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (number != 0) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.int32Size(number)
+    if (options.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(3) * options.size) + options.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -577,8 +577,8 @@ private fun Option.protoMergeImpl(plus: Option?): Option = plus?.copy(
 
 private fun Option.protoSizeImpl(): Int {
     var protoSize = 0
-    if (name.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(name)
-    if (value != null) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.messageSize(value)
+    if (name.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(name)
+    if (value != null) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
@@ -229,7 +229,7 @@ private fun DoubleValue.protoMergeImpl(plus: DoubleValue?): DoubleValue = plus?.
 
 private fun DoubleValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0.0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.doubleSize(value)
+    if (value != 0.0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.doubleSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -274,7 +274,7 @@ private fun FloatValue.protoMergeImpl(plus: FloatValue?): FloatValue = plus?.cop
 
 private fun FloatValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0.0F) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.floatSize(value)
+    if (value != 0.0F) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.floatSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -319,7 +319,7 @@ private fun Int64Value.protoMergeImpl(plus: Int64Value?): Int64Value = plus?.cop
 
 private fun Int64Value.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int64Size(value)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -364,7 +364,7 @@ private fun UInt64Value.protoMergeImpl(plus: UInt64Value?): UInt64Value = plus?.
 
 private fun UInt64Value.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0L) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt64Size(value)
+    if (value != 0L) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt64Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -409,7 +409,7 @@ private fun Int32Value.protoMergeImpl(plus: Int32Value?): Int32Value = plus?.cop
 
 private fun Int32Value.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.int32Size(value)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.int32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -454,7 +454,7 @@ private fun UInt32Value.protoMergeImpl(plus: UInt32Value?): UInt32Value = plus?.
 
 private fun UInt32Value.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value != 0) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.uInt32Size(value)
+    if (value != 0) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.uInt32Size(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -499,7 +499,7 @@ private fun BoolValue.protoMergeImpl(plus: BoolValue?): BoolValue = plus?.copy(
 
 private fun BoolValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.boolSize(value)
+    if (value) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.boolSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -544,7 +544,7 @@ private fun StringValue.protoMergeImpl(plus: StringValue?): StringValue = plus?.
 
 private fun StringValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(value)
+    if (value.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -589,7 +589,7 @@ private fun BytesValue.protoMergeImpl(plus: BytesValue?): BytesValue = plus?.cop
 
 private fun BytesValue.protoSizeImpl(): Int {
     var protoSize = 0
-    if (value.array.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.bytesSize(value)
+    if (value.array.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.bytesSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/jsMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/Util.kt
@@ -8,9 +8,9 @@ inline fun ByteArray.asUint8Array() =
 inline fun Uint8Array.asByteArray() =
         Int8Array(buffer, byteOffset, length).unsafeCast<ByteArray>()
 
-actual typealias SizerImpl = pbandk.protobufjs.SizerImpl
+actual typealias Sizer = pbandk.protobufjs.Sizer
 
-actual typealias UtilImpl = pbandk.protobufjs.Util
+actual typealias Util = pbandk.protobufjs.Util
 
 fun Unmarshaller(r: pbandk.protobufjs.Reader, discardUnknownFields: Boolean = false)
         = pbandk.protobufjs.Unmarshaller(r = r, discardUnknownFields = discardUnknownFields)

--- a/runtime/src/jsMain/kotlin/pbandk/protobufjs/Sizer.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/protobufjs/Sizer.kt
@@ -1,5 +1,5 @@
 package pbandk.protobufjs
 
-object SizerImpl : pbandk.impl.SizerImpl(), pbandk.Sizer {
+object Sizer : pbandk.impl.Sizer() {
     override fun stringSize(value: String) = util.utf8.length(value).let { it + uInt32Size(it) }
 }

--- a/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
@@ -1,6 +1,5 @@
 package pbandk.protobufjs
 
-import pbandk.Util
 import pbandk.asUint8Array
 import pbandk.wkt.Timestamp
 import kotlin.js.Date
@@ -16,17 +15,17 @@ val Long.protobufjsLong: dynamic
 
 fun Long.Companion.fromProtobufjsLong(l: dynamic) = js("Kotlin").Long.fromBits(l.low, l.high) as Long
 
-object Util : Util {
-    override fun stringToUtf8(str: String) = ByteArray(util.utf8.length(str)).also { util.utf8.write(str, it.asUint8Array(), 0) }
-    override fun utf8ToString(bytes: ByteArray) = bytes.asUint8Array().let { util.utf8.read(it, 0, it.length) }
+object Util {
+    fun stringToUtf8(str: String) = ByteArray(util.utf8.length(str)).also { util.utf8.write(str, it.asUint8Array(), 0) }
+    fun utf8ToString(bytes: ByteArray) = bytes.asUint8Array().let { util.utf8.read(it, 0, it.length) }
 
-    override fun base64ToBytes(str: String) = js("Buffer").from(str, "base64")
-    override fun bytesToBase64(bytes: ByteArray) = js("Buffer").from(bytes).toString("base64")
+    fun base64ToBytes(str: String) = js("Buffer").from(str, "base64")
+    fun bytesToBase64(bytes: ByteArray) = js("Buffer").from(bytes).toString("base64")
 
-    override fun timestampToString(ts: Timestamp.JsonMapper) =
+    fun timestampToString(ts: Timestamp.JsonMapper) =
         Date(((ts.seconds ?: 0) * 1000) + ((ts.nanos ?: 0) / 1_000_000)).toISOString()
 
-    override fun stringToTimestamp(str: String) = Date(str).getTime().let {
+    fun stringToTimestamp(str: String) = Date(str).getTime().let {
         Timestamp.JsonMapper(
             seconds = floor(it / 1000.0).toLong(),
             nanos = (it % 1000 * 1_000_000).toInt()

--- a/runtime/src/jvmMain/kotlin/pbandk/Sizer.kt
+++ b/runtime/src/jvmMain/kotlin/pbandk/Sizer.kt
@@ -2,6 +2,6 @@ package pbandk
 
 import com.google.protobuf.CodedOutputStream
 
-actual object SizerImpl : pbandk.impl.SizerImpl(), Sizer {
-    override fun stringSize(value: String) = CodedOutputStream.computeStringSizeNoTag(value)
+actual object Sizer : pbandk.impl.Sizer() {
+    actual override fun stringSize(value: String) = CodedOutputStream.computeStringSizeNoTag(value)
 }

--- a/runtime/src/jvmMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/jvmMain/kotlin/pbandk/Util.kt
@@ -5,18 +5,18 @@ import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-actual object UtilImpl : Util {
-    override fun stringToUtf8(str: String) = str.toByteArray()
-    override fun utf8ToString(bytes: ByteArray) = bytes.toString(Charsets.UTF_8)
+actual object Util {
+    actual fun stringToUtf8(str: String) = str.toByteArray()
+    actual fun utf8ToString(bytes: ByteArray) = bytes.toString(Charsets.UTF_8)
 
-    override fun base64ToBytes(str: String): ByteArray = Base64.getDecoder().decode(str)
-    override fun bytesToBase64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+    actual fun base64ToBytes(str: String): ByteArray = Base64.getDecoder().decode(str)
+    actual fun bytesToBase64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
 
-    override fun timestampToString(ts: Timestamp.JsonMapper): String =
+    actual fun timestampToString(ts: Timestamp.JsonMapper): String =
         DateTimeFormatter.ISO_INSTANT.format(
             Instant.ofEpochSecond(ts.seconds ?: 0, ts.nanos?.toLong() ?: 0)
         )
-    override fun stringToTimestamp(str: String): Timestamp.JsonMapper =
+    actual fun stringToTimestamp(str: String): Timestamp.JsonMapper =
         DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(str, Instant::from).let {
             Timestamp.JsonMapper(it.epochSecond, it.nano)
         }

--- a/runtime/src/jvmTest/kotlin/pbandk/testpb/test.kt
+++ b/runtime/src/jvmTest/kotlin/pbandk/testpb/test.kt
@@ -139,7 +139,7 @@ private fun Foo.protoMergeImpl(plus: Foo?): Foo = plus?.copy(
 
 private fun Foo.protoSizeImpl(): Int {
     var protoSize = 0
-    if (`val`.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(`val`)
+    if (`val`.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(`val`)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -185,7 +185,7 @@ private fun Bar.protoMergeImpl(plus: Bar?): Bar = plus?.copy(
 
 private fun Bar.protoSizeImpl(): Int {
     var protoSize = 0
-    if (foos.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(1) * foos.size) + foos.sumBy(pbandk.SizerImpl::messageSize)
+    if (foos.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(1) * foos.size) + foos.sumBy(pbandk.Sizer::messageSize)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -231,7 +231,7 @@ private fun MessageWithMap.protoMergeImpl(plus: MessageWithMap?): MessageWithMap
 
 private fun MessageWithMap.protoSizeImpl(): Int {
     var protoSize = 0
-    if (map.isNotEmpty()) protoSize += pbandk.SizerImpl.mapSize(1, map, pbandk.testpb.MessageWithMap::MapEntry)
+    if (map.isNotEmpty()) protoSize += pbandk.Sizer.mapSize(1, map, pbandk.testpb.MessageWithMap::MapEntry)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -276,8 +276,8 @@ private fun MessageWithMap.MapEntry.protoMergeImpl(plus: MessageWithMap.MapEntry
 
 private fun MessageWithMap.MapEntry.protoSizeImpl(): Int {
     var protoSize = 0
-    if (key.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.stringSize(key)
-    if (value.isNotEmpty()) protoSize += pbandk.SizerImpl.tagSize(2) + pbandk.SizerImpl.stringSize(value)
+    if (key.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+    if (value.isNotEmpty()) protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.stringSize(value)
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }
@@ -329,8 +329,8 @@ private fun Wrappers.protoMergeImpl(plus: Wrappers?): Wrappers = plus?.copy(
 
 private fun Wrappers.protoSizeImpl(): Int {
     var protoSize = 0
-    if (stringValue != null) protoSize += pbandk.SizerImpl.tagSize(1) + pbandk.SizerImpl.messageSize(pbandk.wkt.StringValue(stringValue))
-    if (uint64Values.isNotEmpty()) protoSize += (pbandk.SizerImpl.tagSize(2) * uint64Values.size) + uint64Values.sumBy { pbandk.SizerImpl.messageSize(pbandk.wkt.UInt64Value(it)) }
+    if (stringValue != null) protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.messageSize(pbandk.wkt.StringValue(stringValue))
+    if (uint64Values.isNotEmpty()) protoSize += (pbandk.Sizer.tagSize(2) * uint64Values.size) + uint64Values.sumBy { pbandk.Sizer.messageSize(pbandk.wkt.UInt64Value(it)) }
     protoSize += unknownFields.entries.sumBy { it.value.size() }
     return protoSize
 }

--- a/runtime/src/nativeMain/kotlin/pbandk/TimeUtil.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/TimeUtil.kt
@@ -1,0 +1,391 @@
+package pbandk
+
+import kotlinx.cinterop.*
+import pbandk.wkt.Timestamp
+import platform.posix.*
+
+/*
+These functions are adapted from the similarly-named functions in the protobuf C++ library:
+https://github.com/protocolbuffers/protobuf/blob/a104dffcb6b1958a424f5fa6f9e6bdc0ab9b6f9e/src/google/protobuf/stubs/time.cc
+*/
+
+// The range of timestamp values we support.
+private const val MIN_TIME = -62135596800L  // 0001-01-01T00:00:00
+private const val MAX_TIME = 253402300799L  // 9999-12-31T23:59:59
+
+private const val NANOS_PER_MILLISECOND = 1000000
+private const val NANOS_PER_MICROSECOND = 1000
+
+private const val SECONDS_PER_MINUTE = 60L
+private const val SECONDS_PER_HOUR = 3600L
+private const val SECONDS_PER_DAY = SECONDS_PER_HOUR * 24
+private const val SECONDS_PER_400_YEARS = SECONDS_PER_DAY * (400 * 365 + 400 / 4 - 3)
+
+// Seconds from 0001-01-01T00:00:00 to 1970-01-01T:00:00:00
+private const val SECONDS_FROM_ERA_TO_EPOCH = 62135596800L
+
+// Count the seconds from the given year (start at Jan 1, 00:00) to 100 years
+// after.
+private fun secondsPer100Years(year: Int): Long {
+    return if (year % 400 == 0 || year % 400 > 300) {
+        SECONDS_PER_DAY * (100 * 365 + 100 / 4);
+    } else {
+        SECONDS_PER_DAY * (100 * 365 + 100 / 4 - 1);
+    }
+}
+
+// Count the seconds from the given year (start at Jan 1, 00:00) to 4 years
+// after.
+private fun secondsPer4Years(year: Int): Long {
+    return if ((year % 100 == 0 || year % 100 > 96) && !(year % 400 == 0 || year % 400 > 396)) {
+        // No leap years.
+        SECONDS_PER_DAY * (4 * 365)
+    } else {
+        // One leap years.
+        SECONDS_PER_DAY * (4 * 365 + 1)
+    }
+}
+
+private fun isLeapYear(year: Int) = (year % 400 == 0) || (year % 4 == 0 && year % 100 != 0)
+
+private fun secondsPerYear(year: Int): Long = SECONDS_PER_DAY * (if (isLeapYear(year)) 366 else 365)
+
+private val DAYS_IN_MONTH = arrayOf(
+    0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+)
+
+private fun secondsPerMonth(month: Int, leap: Boolean): Long =
+    SECONDS_PER_DAY * (DAYS_IN_MONTH[month] + if (month == 2 && leap) 1 else 0)
+
+private val DAYS_SINCE_JAN = arrayOf(
+    0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+)
+
+private data class DateTime(
+    val year: Int,
+    val month: Int,
+    val day: Int,
+    val hour: Int,
+    val minute: Int,
+    val second: Int
+) {
+    companion object
+}
+
+// region timestamp formatting
+
+/**
+ * Converts a timestamp (seconds elapsed since 1970-01-01T00:00:00, could be
+ * negative to represent time before 1970-01-01) to DateTime. Throws an exception
+ * if the timestamp is not in the range between 0001-01-01T00:00:00 and
+ * 9999-12-31T23:59:59.
+ */
+private fun DateTime.Companion.fromSeconds(seconds: Long): DateTime {
+    require(seconds in MIN_TIME..MAX_TIME) {
+        "Timestamp seconds outside of allowed range: '$seconds' !in $MIN_TIME..$MAX_TIME"
+    }
+    // It's easier to calculate the DateTime starting from 0001-01-01T00:00:00
+    @Suppress("NAME_SHADOWING")
+    var seconds = seconds + SECONDS_FROM_ERA_TO_EPOCH
+
+    var year = 1
+    if (seconds >= SECONDS_PER_400_YEARS) {
+        val count400years = (seconds / SECONDS_PER_400_YEARS).toInt()
+        year += 400 * count400years
+        seconds %= SECONDS_PER_400_YEARS
+    }
+    while (seconds >= secondsPer100Years(year)) {
+        seconds -= secondsPer100Years(year)
+        year += 100
+    }
+    while (seconds >= secondsPer4Years(year)) {
+        seconds -= secondsPer4Years(year)
+        year += 4
+    }
+    while (seconds >= secondsPerYear(year)) {
+        seconds -= secondsPerYear(year)
+        year += 1
+    }
+    val leap = isLeapYear(year)
+    var month = 1
+    while (seconds >= secondsPerMonth(month, leap)) {
+        seconds -= secondsPerMonth(month, leap)
+        ++month
+    }
+    val day = 1 + (seconds / SECONDS_PER_DAY).toInt()
+    seconds %= SECONDS_PER_DAY
+    val hour = (seconds / SECONDS_PER_HOUR).toInt()
+    seconds %= SECONDS_PER_HOUR
+    val minute = (seconds / SECONDS_PER_MINUTE).toInt()
+    seconds %= SECONDS_PER_MINUTE
+    return DateTime(year, month, day, hour, minute, seconds.toInt())
+}
+
+private fun formatNanos(output: CPointer<ByteVar>, nanos: Int): Int {
+    fun writeFractionalNumber(size: Int, value: Int): Int {
+        val bytesWritten = snprintf(output, size.convert(), "%0${size}d", value)
+        return when {
+            bytesWritten < 0 -> throw PosixException(posix_errno())
+            bytesWritten > size ->
+                throw IllegalStateException("Needed to write $bytesWritten bytes but only had space for $size")
+            else -> bytesWritten
+        }
+    }
+
+    return when {
+        nanos % NANOS_PER_MILLISECOND == 0 -> writeFractionalNumber(3, nanos / NANOS_PER_MILLISECOND)
+        nanos % NANOS_PER_MICROSECOND == 0 -> writeFractionalNumber(6, nanos / NANOS_PER_MICROSECOND)
+        else -> writeFractionalNumber(9, nanos)
+    }
+}
+
+private fun CPointer<ByteVar>.setChecked(index: Int, size: Int, value: Char) {
+    check(index + 1 < size) { "Not enough space in buffer to write '$value': index=$index, size=$size" }
+    this[index] = value.toByte()
+}
+
+/**
+ * Formats a time string in RFC3339 format.
+ *
+ * For example, "2015-05-20T13:29:35.120Z". For nanos, 0, 3, 6 or 9 fractional
+ * digits will be used depending on how many are required to represent the exact
+ * value.
+ *
+ * Note that "nanos" must in the range of [0, 999999999].
+ */
+internal fun formatTime(seconds: Long, nanos: Int): String {
+    // The range of timestamp values we support.
+    require(nanos in 0..999999999) {
+        "Timestamp nanos outside of allowed range: '$nanos' !in 0..999999999"
+    }
+    val time = DateTime.fromSeconds(seconds)
+
+    return memScoped {
+        // The output string will be yyyy-mm-ddThh:mm:ss.sssssssssZ. The fractional seconds component (with
+        // leading period) is optional. If present, it can be up to 9 digits long but can be shorter.
+        val outputBufferSize = 40
+        val output = allocArray<ByteVar>(outputBufferSize)
+        var bytesWritten = snprintf(
+            output, outputBufferSize.convert(), "%04d-%02d-%02dT%02d:%02d:%02d",
+            time.year, time.month, time.day,
+            time.hour, time.minute, time.second
+        )
+        if (bytesWritten < 0) {
+            throw PosixException(posix_errno())
+        } else if (bytesWritten > outputBufferSize) {
+            throw IllegalStateException("Needed to write $bytesWritten bytes but only had space for $outputBufferSize")
+        }
+
+        if (nanos != 0) {
+            output.setChecked(bytesWritten++, outputBufferSize, '.')
+            check(bytesWritten + 9 < outputBufferSize) {
+                "Not enough space in buffer to write nanos: index=$bytesWritten, size=$outputBufferSize"
+            }
+            bytesWritten += formatNanos((output + bytesWritten.toLong())!!, nanos)
+        }
+
+        output.setChecked(bytesWritten++, outputBufferSize, 'Z')
+        output[bytesWritten] = 0
+        output.toKString()
+    }
+}
+
+// endregion
+
+// region timestamp parsing
+
+private data class ParsePosition(var position: Int = 0)
+
+/**
+ * Parses an integer from a string. The method consumes at most [width] chars. Throws `IllegalArgumentException` if
+ * the data does not start with an integer or the integer value does not fall in the range of [minValue]..[maxValue].
+ * Returns the parsed integer and increments [parsePosition] with the number of characters that were parsed.
+ */
+private fun parseInt(str: String, parsePosition: ParsePosition, width: Int, minValue: Int, maxValue: Int): Int {
+    val position = parsePosition.position
+    require(str[position].isDigit()) { "Failed to parse integer at: ${str.substring(position)}" }
+    var value = 0
+    var i = 0
+    while (i < width) {
+        if (str[position + i].isDigit()) {
+            value = value * 10 + (str[position + i] - '0')
+        } else {
+            break
+        }
+        ++i
+    }
+    require(value in minValue..maxValue) { "Integer out of range: $value !in $minValue..$maxValue" }
+    parsePosition.position += i
+    return value
+}
+
+/**
+ * Consumes the fractional parts of a second into nanos. For example, "010" will be parsed to 10000000 nanos.
+ */
+private fun parseNanos(str: String, parsePosition: ParsePosition): Int {
+    val position = parsePosition.position
+    require(str[position].isDigit()) { "Failed to parse nanos at: ${str.substring(position)}" }
+    var value = 0
+    var len = 0
+    // Consume as many digits as there are but only take the first 9 into account.
+    while (str[position + len].isDigit()) {
+        if (len < 9) {
+            value = value * 10 + (str[position + len] - '0')
+        }
+        ++len
+    }
+    parsePosition.position += len
+    while (len < 9) {
+        value *= 10
+        ++len
+    }
+    return value
+}
+
+private fun requireChar(str: String, parsePosition: ParsePosition, char: Char) {
+    require(str[parsePosition.position] == char) {
+        "Expected '$char' at: ${str.substring(parsePosition.position)}"
+    }
+    ++parsePosition.position
+}
+
+// Accept format "HH:MM". E.g., "08:00"
+private fun parseTimezoneOffset(str: String, parsePosition: ParsePosition): Int {
+    val hour = parseInt(str, parsePosition, 2, 0, 23)
+    requireChar(str, parsePosition, ':')
+    val minute = parseInt(str, parsePosition, 2, 0, 59)
+    return (hour * 60 + minute) * 60
+}
+
+// Count the number of seconds elapsed from 0001-01-01T00:00:00 to the given
+// time.
+private val DateTime.secondsSinceCommonEra: Long
+    get() {
+        var result = 0L
+
+        // Years should be between 1 and 9999.
+        check(year in 1..9999) { "Year outside of range: '$year' !in 1..9999" }
+        var calculatedYear = 1
+        if ((year - calculatedYear) >= 400) {
+            val count400years = (year - calculatedYear) / 400
+            result += SECONDS_PER_400_YEARS * count400years
+            calculatedYear += count400years * 400
+        }
+        while ((year - calculatedYear) >= 100) {
+            result += secondsPer100Years(calculatedYear)
+            calculatedYear += 100
+        }
+        while ((year - calculatedYear) >= 4) {
+            result += secondsPer4Years(calculatedYear)
+            calculatedYear += 4
+        }
+        while (year > calculatedYear) {
+            result += secondsPerYear(calculatedYear)
+            ++calculatedYear
+        }
+
+        // Months should be between 1 and 12.
+        check(month in 1..12) { "Month outside of range: '$month' !in 1..12" }
+        result += SECONDS_PER_DAY * DAYS_SINCE_JAN[month]
+        if (month > 2 && isLeapYear(calculatedYear)) {
+            result += SECONDS_PER_DAY
+        }
+
+        check(day in 1..(DAYS_IN_MONTH[month] + if (month == 2 && isLeapYear(calculatedYear)) 1 else 0)) {
+            "Day outside of range: '$day' !in 1..${(DAYS_IN_MONTH[month] + if (month == 2 && isLeapYear(calculatedYear)) 1 else 0)}"
+        }
+        result += SECONDS_PER_DAY * (this.day - 1)
+        result += SECONDS_PER_HOUR * this.hour +
+                SECONDS_PER_MINUTE * this.minute +
+                this.second
+        return result
+    }
+
+private fun DateTime.validate(): Boolean {
+    if (year !in 1..9999 ||
+        month !in 1..12 ||
+        day !in 1..31 ||
+        hour !in 0..23 ||
+        minute !in 0..59 ||
+        second !in 0..59
+    ) {
+        return false;
+    }
+    return if (month == 2 && isLeapYear(year)) {
+        day <= DAYS_IN_MONTH[month] + 1;
+    } else {
+        day <= DAYS_IN_MONTH[month];
+    }
+}
+
+/**
+ * Converts DateTime to a timestamp (seconds since 1970-01-01T00:00:00).
+ * Throws an exception if the DateTime is not valid or is not in the valid range.
+ */
+private fun DateTime.toSeconds(): Long {
+    require(validate()) { "Invalid date/time values" }
+    return secondsSinceCommonEra - SECONDS_FROM_ERA_TO_EPOCH
+}
+
+/**
+ * Parses a time string. This method accepts RFC3339 date/time string with UTC
+ * offset. For example, "2015-05-20T13:29:35.120-08:00".
+ */
+internal fun parseTime(str: String): Timestamp {
+    // We only accept:
+    //   Z-normalized: 2015-05-20T13:29:35.120Z
+    //   With UTC offset: 2015-05-20T13:29:35.120-08:00
+
+    val parsePosition = ParsePosition()
+
+    // Parse year
+    val year = parseInt(str, parsePosition, 4, 1, 9999)
+    // Expect '-'
+    requireChar(str, parsePosition, '-')
+    // Parse month
+    val month = parseInt(str, parsePosition, 2, 1, 12)
+    // Expect '-'
+    requireChar(str, parsePosition, '-')
+    // Parse day
+    val day = parseInt(str, parsePosition, 2, 1, 31)
+    // Expect 'T'
+    requireChar(str, parsePosition, 'T')
+    // Parse hour
+    val hour = parseInt(str, parsePosition, 2, 0, 23)
+    // Expect ':'
+    requireChar(str, parsePosition, ':')
+    // Parse minute
+    val minute = parseInt(str, parsePosition, 2, 0, 59)
+    // Expect ':'
+    requireChar(str, parsePosition, ':')
+    // Parse second
+    val second = parseInt(str, parsePosition, 2, 0, 59)
+
+    val seconds = DateTime(year, month, day, hour, minute, second).toSeconds()
+
+    // Parse nanoseconds.
+    val nanos = if (str[parsePosition.position] == '.') {
+        ++parsePosition.position
+        // Parse nanoseconds.
+        parseNanos(str, parsePosition)
+    } else {
+        0
+    }
+
+    // Parse UTC offsets.
+    val secondsOffset = when (str[parsePosition.position++]) {
+        'Z' -> 0
+        '+' -> -parseTimezoneOffset(str, parsePosition)
+        '-' -> parseTimezoneOffset(str, parsePosition)
+        else -> throw IllegalArgumentException(
+            "Expected 'Z' or timezone offset at: ${str.substring(parsePosition.position - 1)}"
+        )
+    }
+    require(parsePosition.position == str.length) {
+        "Didn't parse entire string: position=${parsePosition.position}, length=${str.length}"
+    }
+
+    return Timestamp(seconds = seconds + secondsOffset, nanos = nanos)
+}
+
+// endregion

--- a/runtime/src/nativeMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Util.kt
@@ -2,12 +2,12 @@ package pbandk
 
 import pbandk.impl.AbstractUtil
 
-actual object SizerImpl: pbandk.impl.SizerImpl(), Sizer
+actual object Sizer : pbandk.impl.Sizer()
 
 @OptIn(ExperimentalStdlibApi::class)
-actual object UtilImpl : AbstractUtil(), Util {
-        override fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
-        override fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
+actual object Util : AbstractUtil() {
+        actual fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
+        actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
 }
 
 internal actual fun unmarshallerByteArray(arr: ByteArray): Unmarshaller =

--- a/runtime/src/nativeMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Util.kt
@@ -1,16 +1,29 @@
 package pbandk
 
+import platform.posix.*
 import pbandk.impl.AbstractUtil
+import pbandk.wkt.Timestamp
+
+internal class PosixException(val errno: Int) : RuntimeException(
+    strerror(errno)?.toString() ?: "Error with unknown errno: $errno"
+)
 
 actual object Sizer : pbandk.impl.Sizer()
 
-@OptIn(ExperimentalStdlibApi::class)
 actual object Util : AbstractUtil() {
-        actual fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
-        actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
+    actual fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
+
+    actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
+
+    actual fun timestampToString(ts: Timestamp.JsonMapper): String = formatTime(ts.seconds ?: 0, ts.nanos ?: 0)
+
+    actual fun stringToTimestamp(str: String): Timestamp.JsonMapper = parseTime(str).let {
+        Timestamp.JsonMapper(it.seconds, it.nanos)
+    }
 }
 
 internal actual fun unmarshallerByteArray(arr: ByteArray): Unmarshaller =
-        pbandk.impl.Unmarshaller.fromByteArray(arr)
+    pbandk.impl.Unmarshaller.fromByteArray(arr)
+
 internal actual fun marshallerAllocate(size: Int): ByteArrayMarshaller =
-        pbandk.impl.ByteArrayMarshaller.allocate(size)
+    pbandk.impl.ByteArrayMarshaller.allocate(size)

--- a/runtime/src/nativeMain/kotlin/pbandk/Util.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Util.kt
@@ -1,7 +1,14 @@
 package pbandk
 
+import pbandk.impl.AbstractUtil
+
 actual object SizerImpl: pbandk.impl.SizerImpl(), Sizer
-actual typealias UtilImpl = pbandk.impl.UtilImpl
+
+@OptIn(ExperimentalStdlibApi::class)
+actual object UtilImpl : AbstractUtil(), Util {
+        override fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
+        override fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
+}
 
 internal actual fun unmarshallerByteArray(arr: ByteArray): Unmarshaller =
         pbandk.impl.Unmarshaller.fromByteArray(arr)


### PR DESCRIPTION
I figured out why the native conformance binary wasn't being built: gradle was skipping over the task because there were no source files in `conformance/native/src`. I've added a one-line wrapper around the `main` function in `conformance-lib` to get the binary building.

I also renamed `UtilImpl` and `SizerImpl` back to `Util` and `Sizer`, as I had suggested in my PR comments, and I removed the experimental annotations on the common runtime API.

Lastly, I fixed an issue I was seeing with the `nativeMain` source set. Kotlin 1.3 doesn't have great support for these kinds of "intermediate" source sets that sit between the `commonMain` source set and a platform-specific source set. This will be handled better in Kotlin 1.4. But for now the best workaround is to just include the `nativeMain` source directory in multiple source sets.